### PR TITLE
[0.3.7] Unified render pipeline, shared caches, Vulkan validation fix…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 
 # Build
 build/
+build_asan/
 external/unity/*
 .koilo_reflect_cache.json
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,39 +4,80 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.7] - 2026-3-20
+Unified render pipeline, shared caches, Vulkan validation fixes, and clean build fixes.
+
+### Added
+- Unified `RenderPipeline` using `IRHIDevice`, replacing duplicated backend scene traversal
+- Shared `MeshCache`, `TextureCache`, and `MaterialBinder` for backend-agnostic resource management
+- `ShaderResolver` for built-in shader name mapping (blit, overlay, debug line, pink error, sky)
+- Deferred descriptor set write pattern for scene set 0 with automatic re-allocation on post-flush writes
+- Per-frame deferred buffer and texture deletion queued behind GPU fence waits
+- Per-frame descriptor pools (one per frame in flight)
+- `sampleAfterPass` flag on `RHIColorAttachment` for render pass final layout control
+- `r_backend` CVar for runtime render backend selection
+- Swapchain render pass API on `IRHIDevice`
+- `build.sh` flags: `--no-vulkan`, `--no-opengl`, `--software-only`, `--skip-ns`, `--debug`
+- SDL3Backend fallback display for pure software-only builds (no GL/VK dependency)
+
+### Changed
+- Vulkan descriptor set layouts restructured into scene (3 sets) and blit (2 sets) pipelines
+- `BindUniformBuffer` fully deferred for scene set 0, no immediate Vulkan calls
+- `BindPipeline` uses effective-layout-aware cache invalidation
+- `BeginFrame` reordered so fence wait precedes pool reset and deferred deletion flush
+- `UploadLights` now runs before `RenderSky` so all set 0 bindings populate before first draw
+- KSL modules expose SPIR-V accessors; registry gains `GetModuleByName`
+- SDL3Host frame loop updated for RenderFrameGPU -> BlitToScreen -> Overlay -> UI -> Present sequence
+- Removed `updatekoiloregistry.py` from CMake build (reflection registry is manual-only now)
+- Reflection entry generator classifies GPU backend paths as platform-specific (software-only linker fix)
+
+### Fixed
+- Descriptor set 0 incomplete bindings from per-call allocation replaced with deferred accumulation
+- Descriptor set updated after bind (UPDATE_AFTER_BIND violation) fixed with fresh-set replay
+- Buffer and texture destruction while GPU in-flight via per-frame deferred deletion queues
+- Render pipeline binding order causing partial set 0 flushes before lights were uploaded
+- Descriptor type mismatch from stale pipeline layout carrying across frames
+- Descriptor pool reset while other frame's command buffer still in-flight
+- Offscreen-to-blit image layout transition missing proper subpass dependency
+- Sky and pink error shader vertex format mismatches
+- Overlay rendering outside active render pass
+- Texture upload missing TransferDst usage flag
+- Broken KL_* reflection macros in 18+ files that prevented clean builds
+- Clean build from scratch now works for all backend configurations
+
 ## [0.3.6] - 2026-3-18
 Render Hardware Interface (RHI) abstraction layer with Vulkan and OpenGL drivers.
 
 ### Added
-- **RHI type system** (`engine/koilo/systems/render/rhi/rhi_types.hpp`, 306 lines)
-  - 7 opaque handle types with null sentinels: Buffer, Texture, Shader, Pipeline, RenderPass, Framebuffer, DescriptorSet
-  - 14 pixel/depth formats (R8 through D32F_S8), buffer/texture usage flags, shader stages
-  - Complete pipeline state: topology, rasterizer, depth/stencil, blend, vertex attributes
-  - Descriptor structs: `RHIBufferDesc`, `RHITextureDesc`, `RHIPipelineDesc`, `RHIRenderPassDesc`
-  - Utility helpers: `RHIFormatBytesPerPixel`, `RHIFormatIsDepth`, `HasFlag` operators
+- **RHI type system** (`engine/koilo/systems/render/rhi/rhi_types.hpp`)
+ - 7 opaque handle types with null sentinels: Buffer, Texture, Shader, Pipeline, RenderPass, Framebuffer, DescriptorSet
+ - 14 pixel/depth formats (R8 through D32F_S8), buffer/texture usage flags, shader stages
+ - Complete pipeline state: topology, rasterizer, depth/stencil, blend, vertex attributes
+ - Descriptor structs: `RHIBufferDesc`, `RHITextureDesc`, `RHIPipelineDesc`, `RHIRenderPassDesc`
+ - Utility helpers: `RHIFormatBytesPerPixel`, `RHIFormatIsDepth`, `HasFlag` operators
 - **RHI device interface** (`engine/koilo/systems/render/rhi/rhi_device.hpp`)
-  - `IRHIDevice` pure virtual interface (~35 methods) covering lifecycle, capabilities, resource CRUD, data transfer, command recording, and presentation
-  - Backend-agnostic contract enabling single render pipeline for all GPU APIs
+ - `IRHIDevice` pure virtual interface (~35 methods) covering lifecycle, capabilities, resource CRUD, data transfer, command recording, and presentation
+ - Backend-agnostic contract enabling single render pipeline for all GPU APIs
 - **RHI capability system** (`engine/koilo/systems/render/rhi/rhi_caps.hpp`)
-  - `RHIFeature` enum (10 features): timestamp queries, compute, multi-draw indirect, bindless textures, push constants, storage buffers, geometry/tessellation shaders, async compute, depth clamp
-  - `RHILimits` struct (14 hardware limits) queried from device at initialization
-- **Vulkan RHI driver** (`engine/koilo/systems/render/rhi/vulkan/`, 1504 lines)
-  - Full `IRHIDevice` implementation using Vulkan API with SlotArray handle-VkObject mapping
-  - Resource lifecycle: buffer/texture/shader/pipeline/renderpass/framebuffer create/destroy
-  - Command recording: render pass begin/end, pipeline/buffer/texture binding, draw/draw-indexed
-  - Descriptor pool with per-frame reset to prevent set exhaustion
-  - Push constants, dynamic viewport/scissor, staging buffer transfers with layout transitions
-  - Device limit/feature queries from `VkPhysicalDeviceProperties` and `VkPhysicalDeviceFeatures`
-- **OpenGL RHI driver** (`engine/koilo/systems/render/rhi/opengl/`, 1077 lines)
-  - Full `IRHIDevice` implementation using OpenGL 3.3+ with immediate-mode GL calls
-  - SlotArray pattern matching Vulkan driver for consistent handle management
-  - Format conversion tables (RHIFormat <-> GL internal/pixel/type), topology/blend/compare mapping
-  - Push constants emulated via reserved UBO at binding 7
-  - Persistent VAO with lazy reconfiguration on vertex state change
-  - Proper ordered shutdown: framebuffers - pipelines - shaders - textures - buffers
-- **RHI smoke tests** (`tests/engine/systems/render/rhi/`, 12 tests)
-  - Handle null sentinel and equality, format helpers, usage flag composition
-  - Descriptor struct defaults, capability feature flags, limits defaults
+ - `RHIFeature` enum (10 features): timestamp queries, compute, multi-draw indirect, bindless textures, push constants, storage buffers, geometry/tessellation shaders, async compute, depth clamp
+ - `RHILimits` struct (14 hardware limits) queried from device at initialization
+- **Vulkan RHI driver** (`engine/koilo/systems/render/rhi/vulkan/`)
+ - Full `IRHIDevice` implementation using Vulkan API with SlotArray handle-VkObject mapping
+ - Resource lifecycle: buffer/texture/shader/pipeline/renderpass/framebuffer create/destroy
+ - Command recording: render pass begin/end, pipeline/buffer/texture binding, draw/draw-indexed
+ - Descriptor pool with per-frame reset to prevent set exhaustion
+ - Push constants, dynamic viewport/scissor, staging buffer transfers with layout transitions
+ - Device limit/feature queries from `VkPhysicalDeviceProperties` and `VkPhysicalDeviceFeatures`
+- **OpenGL RHI driver** (`engine/koilo/systems/render/rhi/opengl/`)
+ - Full `IRHIDevice` implementation using OpenGL 3.3+ with immediate-mode GL calls
+ - SlotArray pattern matching Vulkan driver for consistent handle management
+ - Format conversion tables (RHIFormat <-> GL internal/pixel/type), topology/blend/compare mapping
+ - Push constants emulated via reserved UBO at binding 7
+ - Persistent VAO with lazy reconfiguration on vertex state change
+ - Proper ordered shutdown: framebuffers - pipelines - shaders - textures - buffers
+- **RHI smoke tests** (`tests/engine/systems/render/rhi/`)
+ - Handle null sentinel and equality, format helpers, usage flag composition
+ - Descriptor struct defaults, capability feature flags, limits defaults
 
 ### Changed
 - **CMake** - RHI driver sources excluded from main glob and conditionally compiled via display CMakeLists (Vulkan section / OpenGL section), matching existing backend pattern
@@ -48,22 +89,22 @@ Runtime inspection, console intelligence, state snapshots, and TCP event streami
 
 ### Added
 - **Entity console commands** (`engine/koilo/kernel/console/entity_commands.cpp`)
-  - `entity.list [tag]` - enumerate all live entities with optional tag filter
-  - `entity.inspect <id|tag>` - show transform, velocity, scene node, and component details
-  - `entity.set <id>.<field> <value>` - set entity position, scale, velocity, or tag at runtime
-  - `entity.watch <id>.<field>` / `entity.unwatch` - pin entity fields to the debug overlay
-  - `scene.hierarchy` - walk and print the scene graph tree with node names, meshes, and positions
-  - `help --json` - structured JSON output of the full command registry for tooling
+ - `entity.list [tag]` - enumerate all live entities with optional tag filter
+ - `entity.inspect <id|tag>` - show transform, velocity, scene node, and component details
+ - `entity.set <id>.<field> <value>` - set entity position, scale, velocity, or tag at runtime
+ - `entity.watch <id>.<field>` / `entity.unwatch` - pin entity fields to the debug overlay
+ - `scene.hierarchy` - walk and print the scene graph tree with node names, meshes, and positions
+ - `help --json` - structured JSON output of the full command registry for tooling
 - **State save/load system** (`state.save`, `state.load`, `state.list`)
-  - Saves entity transforms + velocities, CVars, and camera position to named snapshots
-  - Tag-based entity matching on restore for cross-session state transfer
-  - Snapshots stored as `states/<name>/` with `entities.json`, `cvars.cfg`, `camera.json`
+ - Saves entity transforms + velocities, CVars, and camera position to named snapshots
+ - Tag-based entity matching on restore for cross-session state transfer
+ - Snapshots stored as `states/<name>/` with `entities.json`, `cvars.cfg`, `camera.json`
 - **TCP event subscription** (`engine/koilo/kernel/console/event_bridge.hpp`)
-  - `EventBridge` service bridges MessageBus events to subscribed TCP console clients
-  - `subscribe <event,...>` / `unsubscribe [event,...]` / `subscriptions` commands
-  - Per-client subscription tracking with thread-local token per connection
-  - Supports all 14 built-in event types (module, asset, scene, entity lifecycle)
-  - JSON-line push format for real-time event streaming to external tools
+ - `EventBridge` service bridges MessageBus events to subscribed TCP console clients
+ - `subscribe <event,...>` / `unsubscribe [event,...]` / `subscriptions` commands
+ - Per-client subscription tracking with thread-local token per connection
+ - Supports all 14 built-in event types (module, asset, scene, entity lifecycle)
+ - JSON-line push format for real-time event streaming to external tools
 - **`ScriptEntityManager::GetAllEntities()`** - public method to iterate all valid entities
 
 ### Changed
@@ -75,57 +116,57 @@ Service registration, CVar system, structured logging, module modularization, an
 
 ### Added
 - **CVar system** (`engine/koilo/kernel/cvar/`)
-  - `CVar<T>` template with int, float, bool, and string types
-  - Automatic registration, console integration, and change callbacks
-  - `sim_cvars` - simulation pause/step CVars for frame debugging
-  - `render_cvars` - wireframe, culling, depth test, and max FPS CVars
-  - Console commands: `cvar.list`, `cvar.get`, `cvar.set`, `cvar.reset`
+ - `CVar<T>` template with int, float, bool, and string types
+ - Automatic registration, console integration, and change callbacks
+ - `sim_cvars` - simulation pause/step CVars for frame debugging
+ - `render_cvars` - wireframe, culling, depth test, and max FPS CVars
+ - Console commands: `cvar.list`, `cvar.get`, `cvar.set`, `cvar.reset`
 - **Config system** (`engine/koilo/kernel/config/`)
-  - `ConfigStore` - hierarchical key-value configuration with INI-style persistence
-  - `IConfigProvider` interface for pluggable config backends
-  - Console commands: `config.get`, `config.set`, `config.list`, `config.save`, `config.load`
+ - `ConfigStore` - hierarchical key-value configuration with INI-style persistence
+ - `IConfigProvider` interface for pluggable config backends
+ - Console commands: `config.get`, `config.set`, `config.list`, `config.save`, `config.load`
 - **Structured logging** (`engine/koilo/kernel/logging/`)
-  - `KL_LOG`, `KL_WARN`, `KL_ERR` macros with channel-tagged output
-  - `LogSystem` with per-channel verbosity, ring buffer history, and output sinks
-  - Console commands: `log.level`, `log.history`, `log.channels`, `log.filter`
+ - `KL_LOG`, `KL_WARN`, `KL_ERR` macros with channel-tagged output
+ - `LogSystem` with per-channel verbosity, ring buffer history, and output sinks
+ - Console commands: `log.level`, `log.history`, `log.channels`, `log.filter`
 - **Thread pool** (`engine/koilo/kernel/thread_pool.*`)
-  - Work-stealing thread pool with priority queues (Low, Normal, High)
-  - Registered as kernel service; used by console socket and asset pipeline
+ - Work-stealing thread pool with priority queues (Low, Normal, High)
+ - Registered as kernel service; used by console socket and asset pipeline
 - **Debug overlay** (`engine/koilo/kernel/debug_overlay.*`)
-  - FPS counter, frame time graph, and memory stats overlay
-  - Toggleable via CVar or console command
+ - FPS counter, frame time graph, and memory stats overlay
+ - Toggleable via CVar or console command
 - **Module implementations** (IModule-based kernel modules)
-  - `SceneModule` - scene and camera lifecycle as a kernel module
-  - `InputModule` - input state management as a kernel module
-  - `RenderModule` - render backend orchestration as a kernel module
-  - `UIModule` - UI system lifecycle as a kernel module
-  - `ParticleModule` - particle system as a kernel module
+ - `SceneModule` - scene and camera lifecycle as a kernel module
+ - `InputModule` - input state management as a kernel module
+ - `RenderModule` - render backend orchestration as a kernel module
+ - `UIModule` - UI system lifecycle as a kernel module
+ - `ParticleModule` - particle system as a kernel module
 - **Console commands**
-  - `utility_commands.cpp` - uptime, version, clear, echo, help improvements
-  - `log_commands.cpp` - structured log querying and channel management
-  - `message_commands.cpp` - message bus tap/untap/send/dispatch/flush
-  - `service_commands.cpp` - service listing with type info and health checks
+ - `utility_commands.cpp` - uptime, version, clear, echo, help improvements
+ - `log_commands.cpp` - structured log querying and channel management
+ - `message_commands.cpp` - message bus tap/untap/send/dispatch/flush
+ - `service_commands.cpp` - service listing with type info and health checks
 
 ### Changed
 - **Service registration** (`register_services.cpp`, `service_registry.*`)
-  - Services now registered with string names and typed accessors
-  - Thread pool, config store, CVar system, and log system registered as kernel services
+ - Services now registered with string names and typed accessors
+ - Thread pool, config store, CVar system, and log system registered as kernel services
 - **Module manager** (`module_manager.*`)
-  - Phase-ordered initialization (Core -> Simulation -> Render -> Overlay)
-  - Capability checking integrated into module lifecycle
+ - Phase-ordered initialization (Core -> Simulation -> Render -> Overlay)
+ - Capability checking integrated into module lifecycle
 - **Kernel** (`kernel.cpp/hpp`)
-  - Expanded with CVar system, config store, and log system ownership
-  - `Shutdown()` dispatches `MSG_SHUTDOWN` signal before module teardown
+ - Expanded with CVar system, config store, and log system ownership
+ - `Shutdown()` dispatches `MSG_SHUTDOWN` signal before module teardown
 - **Asset job queue** (`asset_job_queue.*`)
-  - Migrated from internal thread to kernel thread pool
-  - Priority-based job scheduling
+ - Migrated from internal thread to kernel thread pool
+ - Priority-based job scheduling
 - **Vulkan render backend** (`vulkan_render_backend.*`)
-  - CVar-driven wireframe, culling, and depth test toggling
-  - Pipeline cache rebuild on CVar change
+ - CVar-driven wireframe, culling, and depth test toggling
+ - Pipeline cache rebuild on CVar change
 - **Script engine module initialization** (`koiloscript_engine.cpp`)
-  - `moduleLoader_.InitializeAll()` now called before `BuildCamera()` so scene/camera modules are available during setup
+ - `moduleLoader_.InitializeAll()` now called before `BuildCamera()` so scene/camera modules are available during setup
 - **Render loop idle-skip** (`sdl3_host.hpp`)
-  - Idle-skip optimization now requires at least 2 rendered frames before activating, ensuring the first frame is presented and the window becomes visible
+ - Idle-skip optimization now requires at least 2 rendered frames before activating, ensuring the first frame is presented and the window becomes visible
 
 ### Fixed
 - **Vulkan validation errors on shutdown** - Early break in render loop on quit signal prevents submitting command buffers with stale image layouts; `vkDeviceWaitIdle()` replaces final `SwapOnly()` during teardown
@@ -139,42 +180,42 @@ Vulkan render backend, kernel architecture, module system, and compile-time back
 
 ### Added
 - **Vulkan render backend** (`engine/koilo/systems/render/vk/`)
-  - Full Vulkan rendering pipeline with SPIR-V shader compilation
+ - Full Vulkan rendering pipeline with SPIR-V shader compilation
 - **Vulkan display backend** (`engine/koilo/systems/display/backends/gpu/vulkanbackend.*`)
-  - SDL3 + Vulkan surface integration with multi-GPU enumeration and selection
-  - Discrete GPU preference with automatic fallback
-  - VSync support, fullscreen toggle, and dynamic window resizing
-  - `IGPUDisplayBackend` interface shared with OpenGL backend
+ - SDL3 + Vulkan surface integration with multi-GPU enumeration and selection
+ - Discrete GPU preference with automatic fallback
+ - VSync support, fullscreen toggle, and dynamic window resizing
+ - `IGPUDisplayBackend` interface shared with OpenGL backend
 - **Kernel architecture** (`engine/koilo/kernel/`)
-  - `KoiloKernel` - central engine kernel with service registry, message bus, and module manager
-  - `ServiceRegistry` - name-based typed service discovery
-  - `MessageBus` - ring-buffered pub/sub messaging with deferred and immediate delivery
-  - `ModuleManager` - module lifecycle, phase-ordered initialization, dependency resolution
-  - `IModule` - unified module interface with Initialize/Update/Render/Shutdown lifecycle
-  - Capability-based permission system for module sandboxing
-  - Message types for module lifecycle, assets, scene, and ECS events
+ - `KoiloKernel` - central engine kernel with service registry, message bus, and module manager
+ - `ServiceRegistry` - name-based typed service discovery
+ - `MessageBus` - ring-buffered pub/sub messaging with deferred and immediate delivery
+ - `ModuleManager` - module lifecycle, phase-ordered initialization, dependency resolution
+ - `IModule` - unified module interface with Initialize/Update/Render/Shutdown lifecycle
+ - Capability-based permission system for module sandboxing
+ - Message types for module lifecycle, assets, scene, and ECS events
 - **Kernel console** (`engine/koilo/kernel/console/`)
-  - `ConsoleModule` with `CommandRegistry` for extensible command system
-  - `ConsoleSession` with history, tab completion, and output formatting
-  - `ConsoleSocket` - TCP server for remote console access on port 9090
-  - Built-in commands: reflection introspection, memory stats, message bus, service listing, GPU info
-  - `ConsoleWidget` - in-engine UI console panel
+ - `ConsoleModule` with `CommandRegistry` for extensible command system
+ - `ConsoleSession` with history, tab completion, and output formatting
+ - `ConsoleSocket` - TCP server for remote console access on port 9090
+ - Built-in commands: reflection introspection, memory stats, message bus, service listing, GPU info
+ - `ConsoleWidget` - in-engine UI console panel
 - **Kernel memory** (`engine/koilo/kernel/memory/`)
-  - Arena allocator (frame-temporary, 4MB default)
-  - Linear allocator (scratch buffer, 1MB default)
-  - Pool allocator for fixed-size block allocation
-  - Allocation tagging for memory tracking
+ - Arena allocator (frame-temporary, 4MB default)
+ - Linear allocator (scratch buffer, 1MB default)
+ - Pool allocator for fixed-size block allocation
+ - Allocation tagging for memory tracking
 - **Kernel asset pipeline** (`engine/koilo/kernel/asset/`)
-  - Asset registry with handle-based reference management
-  - Async job queue with worker thread for background asset loading
-  - Asset manifest and converter registry
+ - Asset registry with handle-based reference management
+ - Async job queue with worker thread for background asset loading
+ - Asset manifest and converter registry
 - **Module implementations**
-  - `AssetModule` - asset loading, file watching, hot-reload via message bus
-  - `PhysicsModule` - physics world integration as kernel module
-  - `AIModule` - behavior tree and pathfinding as kernel module
-  - `AudioModule` - audio system as kernel module
+ - `AssetModule` - asset loading, file watching, hot-reload via message bus
+ - `PhysicsModule` - physics world integration as kernel module
+ - `AIModule` - behavior tree and pathfinding as kernel module
+ - `AudioModule` - audio system as kernel module
 - **SPIR-V shader sources** (`shaders/`)
-  - `scene.vert`, `blit.vert/frag`, `ui.vert/frag` - core Vulkan shaders
+ - `scene.vert`, `blit.vert/frag`, `ui.vert/frag` - core Vulkan shaders
 - `KOILO_USE_OPENGL` CMake option for explicit OpenGL opt-in
 - `koilo_runner.cpp` - standalone script runner entry point
 - Run scripts for all example projects (`examples/*/run.sh`)
@@ -202,15 +243,15 @@ UI code quality: hpp/cpp splits, coding standards fixes, dirty-flag rendering (a
 
 ### Changed
 - **hpp/cpp splits** - Separated header-only UI files into proper hpp/cpp pairs for faster incremental builds and cleaner interfaces:
-  - `ui_context.hpp/cpp` (core context, event handling, widget management)
-  - `draw_list.hpp/cpp` (draw command generation and widget emitters)
-  - `kml_builder.hpp/cpp` (KML markup parser and widget construction)
-  - `kss_parser.hpp/cpp` (KSS stylesheet parser)
-  - `layout.hpp/cpp` (flexbox-style layout engine)
-  - `event.hpp/cpp` (hit testing and event dispatch)
-  - `theme.hpp/cpp` (style resolution and theme management)
-  - `canvas2d.hpp/cpp` (Canvas2D immediate-mode draw context)
-  - `color_picker.hpp/cpp` (HSV color picker panel)
+ - `ui_context.hpp/cpp` (core context, event handling, widget management)
+ - `draw_list.hpp/cpp` (draw command generation and widget emitters)
+ - `kml_builder.hpp/cpp` (KML markup parser and widget construction)
+ - `kss_parser.hpp/cpp` (KSS stylesheet parser)
+ - `layout.hpp/cpp` (flexbox-style layout engine)
+ - `event.hpp/cpp` (hit testing and event dispatch)
+ - `theme.hpp/cpp` (style resolution and theme management)
+ - `canvas2d.hpp/cpp` (Canvas2D immediate-mode draw context)
+ - `color_picker.hpp/cpp` (HSV color picker panel)
 - Aligned all UI source files to project coding standards
 - Dropdown popup rendering deferred to overlay pass so menus draw above sibling widgets
 
@@ -219,7 +260,7 @@ UI code quality: hpp/cpp splits, coding standards fixes, dirty-flag rendering (a
 - Cursor position drift in text fields growing with text length
 - Slider and toggle switch sluggish response from per-pixel dirty marking
 - Shadow opacity too dark from additive overlap of multi-step blur rects
-- `rgba()` alpha values in KSS parsed as 0–1 float now correctly mapped to 0–255
+- `rgba()` alpha values in KSS parsed as 0-1 float now correctly mapped to 0-255
 - Number spinner vertical sizing asymmetry
 - Tree node showing expand icon on leaf nodes with no children
 - Dropdown items not clickable (hit test returning child labels instead of dropdown)
@@ -237,15 +278,15 @@ UI system, rendering fixes, and naming cleanup.
 
 ### Added
 - **UI system** (`engine/koilo/systems/ui/`)
-  - KML (Koilo Markup Language) and KSS (Koilo Style Sheet) for declarative UI
-  - Custom TTF renderer for UI text; upgrade from characters used in previous Canvas2D examples
-  - 23 widget types: panel, button, label, slider, checkbox, dropdown, treenode, splitpane, floatingpanel, and others
-  - GPU-accelerated and software rendering paths
-  - CSS-like selectors, pseudo-classes, variables, media queries, and transitions
-  - Hierarchy tree view with expand/collapse and connector lines (not finished)
-  - Floating panel system with minimize, close, and bottom tray
-  - UI demo example (`examples/ui_demo/`)
-  - Reference documentation (`docs/ui/kml_kss.md`)
+ - KML (Koilo Markup Language) and KSS (Koilo Style Sheet) for declarative UI
+ - Custom TTF renderer for UI text; upgrade from characters used in previous Canvas2D examples
+ - 23 widget types: panel, button, label, slider, checkbox, dropdown, treenode, splitpane, floatingpanel, and others
+ - GPU-accelerated and software rendering paths
+ - CSS-like selectors, pseudo-classes, variables, media queries, and transitions
+ - Hierarchy tree view with expand/collapse and connector lines (not finished)
+ - Floating panel system with minimize, close, and bottom tray
+ - UI demo example (`examples/ui_demo/`)
+ - Reference documentation (`docs/ui/kml_kss.md`)
 
 ### Changed
 - Software render path now swaps immediately after present for reliable display on Wayland
@@ -255,26 +296,26 @@ Major architectural restructure: PTX -> Koilo rename, unified engine layout, Koi
 
 ### Added
 - **KoiloScript Language (KSL)** (`engine/koilo/ksl/`)
-  - Compile-time shader system replacing the old material/shader class hierarchy
-  - ELF-based module loader, symbol resolution, and shader registry
-  - 19 built-in KSL shaders (`shaders/*.ksl.hpp`): PBR, Phong, gradient, procedural noise, audio reactive, spectrum analyzer, and others
-  - KSL compiler and codegen tooling (`tools/ksl/`)
-  - VSCode syntax extension (`tools/vscode-koiloscript/`)
+ - Compile-time shader system replacing the old material/shader class hierarchy
+ - ELF-based module loader, symbol resolution, and shader registry
+ - 19 built-in KSL shaders (`shaders/*.ksl.hpp`): PBR, Phong, gradient, procedural noise, audio reactive, spectrum analyzer, and others
+ - KSL compiler and codegen tooling (`tools/ksl/`)
+ - VSCode syntax extension (`tools/vscode-koiloscript/`)
 - **SplinePath system** (`engine/koilo/core/math/`)
-  - 1D and 3D spline path interpolation with Catmull-Rom support
+ - 1D and 3D spline path interpolation with Catmull-Rom support
 - **SDL2 platform backend** (`engine/koilo/platform/sdl2_host.hpp`, `engine/koilo/systems/display/backends/gpu/sdl2backend.*`)
-  - SDL2 host with input helper for windowed rendering
+ - SDL2 host with input helper for windowed rendering
 - **OpenGL render backend** (`engine/koilo/systems/render/gl/`)
-  - Render backend abstraction with OpenGL and software implementations
-  - Factory pattern for backend selection
+ - Render backend abstraction with OpenGL and software implementations
+ - Factory pattern for backend selection
 - **KoiloMesh asset pipeline** (`tools/asset-conversion/`)
-  - Offline OBJ/FBX -> `.kmesh` converter with UV and texture support
-  - Binary mesh format with KOIM header, vertex/index/UV/material chunks
+ - Offline OBJ/FBX -> `.kmesh` converter with UV and texture support
+ - Binary mesh format with KOIM header, vertex/index/UV/material chunks
 - **Example projects** (`examples/`)
-  - Module demos, OBJ scene loading, 3D scene, space shooter, stress test, and syntax demo
+ - Module demos, OBJ scene loading, 3D scene, space shooter, stress test, and syntax demo
 - **Documentation** (`docs/`)
-  - Architecture overview and optimization guide
-  - KSL specification, reflection system, KoiloMesh format, custom modules, KoiloScript spec
+ - Architecture overview and optimization guide
+ - KSL specification, reflection system, KoiloMesh format, custom modules, KoiloScript spec
 
 ### Changed
 - Unified engine layout: merged `engine/include/` and `engine/src/` into `engine/koilo/`
@@ -295,32 +336,32 @@ Core gameplay systems (ECS, Particles, AI, World Management, Profiling)
 
 ### Added
 - **Entity Component System (ECS)** (`engine/include/koilo/systems/ecs/`)
-  - Entity handles with generation counters for stale handle detection
-  - Dense component storage for cache-friendly iteration
-  - Template-based type-safe component API
-  - Component masks and query system for efficient entity filtering
-  - Core components: `TransformComponent` (wraps existing Transform), `VelocityComponent`, `TagComponent`
+ - Entity handles with generation counters for stale handle detection
+ - Dense component storage for cache-friendly iteration
+ - Template-based type-safe component API
+ - Component masks and query system for efficient entity filtering
+ - Core components: `TransformComponent` (wraps existing Transform), `VelocityComponent`, `TagComponent`
 - **Particle System** (`engine/include/koilo/systems/particles/`)
-  - Particle pooling (pre-allocated, zero runtime allocations)
-  - Multiple emission shapes: Point, Sphere, Box, Cone, Circle
-  - Lifetime-based interpolation for size, color, and alpha
-  - Physics simulation (gravity, velocity, acceleration)
-  - Burst emission and custom update callbacks
+ - Particle pooling (pre-allocated, zero runtime allocations)
+ - Multiple emission shapes: Point, Sphere, Box, Cone, Circle
+ - Lifetime-based interpolation for size, color, and alpha
+ - Physics simulation (gravity, velocity, acceleration)
+ - Burst emission and custom update callbacks
 - **AI System** (`engine/include/koilo/systems/ai/`)
-  - **Behavior Trees**: Composites (Sequence, Selector, Parallel), Decorators (Inverter, Repeater, Succeeder), Leaves (Action, Condition, Wait)
-  - **State Machines**: State callbacks (Enter/Update/Exit), automatic transition checking with conditions
-  - **Pathfinding**: A* algorithm on grid, multiple heuristics (Manhattan, Euclidean, Diagonal), terrain costs, diagonal movement support
+ - **Behavior Trees**: Composites (Sequence, Selector, Parallel), Decorators (Inverter, Repeater, Succeeder), Leaves (Action, Condition, Wait)
+ - **State Machines**: State callbacks (Enter/Update/Exit), automatic transition checking with conditions
+ - **Pathfinding**: A* algorithm on grid, multiple heuristics (Manhattan, Euclidean, Diagonal), terrain costs, diagonal movement support
 - **World Management** (`engine/include/koilo/systems/world/`)
-  - Level loading/unloading with state machine (Unloaded/Loading/Loaded/Active/Unloading)
-  - Level streaming based on viewer position with configurable radius
-  - Level metadata and callbacks (OnLoad/OnUnload)
-  - `LevelSerializer` for JSON/Binary/XML serialization formats
-  - Level/Scene integration (Level can reference Scene for rendering)
+ - Level loading/unloading with state machine (Unloaded/Loading/Loaded/Active/Unloading)
+ - Level streaming based on viewer position with configurable radius
+ - Level metadata and callbacks (OnLoad/OnUnload)
+ - `LevelSerializer` for JSON/Binary/XML serialization formats
+ - Level/Scene integration (Level can reference Scene for rendering)
 - **Profiling Tools** (`engine/include/koilo/systems/profiling/`)
-  - **PerformanceProfiler**: Frame timing, FPS tracking, code section profiling with RAII helpers (`KL_PROFILE_SCOPE`, `KL_PROFILE_FUNCTION`)
-  - **MemoryProfiler**: Allocation tracking by tag, leak detection, peak usage tracking, formatted output (`KL_TRACK_ALLOC`, `KL_TRACK_FREE`)
-  - Historical statistics (min/max/avg over configurable frame history)
-  - Performance and memory reports with percentage breakdowns
+ - **PerformanceProfiler**: Frame timing, FPS tracking, code section profiling with RAII helpers (`KL_PROFILE_SCOPE`, `KL_PROFILE_FUNCTION`)
+ - **MemoryProfiler**: Allocation tracking by tag, leak detection, peak usage tracking, formatted output (`KL_TRACK_ALLOC`, `KL_TRACK_FREE`)
+ - Historical statistics (min/max/avg over configurable frame history)
+ - Performance and memory reports with percentage breakdowns
 
 ### Changed
 - Renamed `SceneSerializer` to `LevelSerializer` for architectural clarity (distinguishes Level serialization from Scene rendering)
@@ -397,33 +438,33 @@ Python wrapper for runtime reflection, and a number of safety/formatting fixes.
 
 ### Added
 - `lib/koilo_python/koilo/reflection.py`
-  - A self-contained `ctypes`-based wrapper that loads the reflection shared
-    library and provides `KoiloReflection`/`KoiloClass`/`KoiloField` helpers for
-    Python usage (demo in `lib/koilo_python/reflection_demo.py`).
+ - A self-contained `ctypes`-based wrapper that loads the reflection shared
+ library and provides `KoiloReflection`/`KoiloClass`/`KoiloField` helpers for
+ Python usage (demo in `lib/koilo_python/reflection_demo.py`).
 - `lib/koilo_c_api/README.md`
-  - Documentation for C ABI layer exposing registry functions
+ - Documentation for C ABI layer exposing registry functions
 - `lib/koilo_python/README.md`
-  - Documentation for using the Python ctypes wrapper and demo commands
+ - Documentation for using the Python ctypes wrapper and demo commands
 
 ### Changed
 - `.scripts/BuildSharedReflectLib.py` (finalized)
-  - Runs `GenerateKoiloAll.py`, scans `lib/koilo` headers for reflection describes,
-    generates `src/reflection_entry_gen.cpp` that forces `Class::Describe()` calls,
-    builds a static `libkoilo` and links it into `koilo_reflect.so`.
+ - Runs `GenerateKoiloAll.py`, scans `lib/koilo` headers for reflection describes,
+ generates `src/reflection_entry_gen.cpp` that forces `Class::Describe()` calls,
+ builds a static `libkoilo` and links it into `koilo_reflect.so`.
 - Header scanner in `.scripts/BuildSharedReflectLib.py` hardened
-  - Skips macro-definition lines and comment/span constructs, filters placeholder
-    tokens (e.g., `CLASS`), avoids nested/unqualified type names, and attempts
-    to qualify names with enclosing namespaces when detected
+ - Skips macro-definition lines and comment/span constructs, filters placeholder
+ tokens (e.g., `CLASS`), avoids nested/unqualified type names, and attempts
+ to qualify names with enclosing namespaces when detected
 
 ### Fixed
 - Ensure `koilo_reflect.so` contains the full registry at runtime by generating
-  and compiling `reflection_entry_gen.cpp` so all `Class::Describe()` statics are
-  emitted and initialised when the shared library is loaded
+ and compiling `reflection_entry_gen.cpp` so all `Class::Describe()` statics are
+ emitted and initialised when the shared library is loaded
 
 ### Notes / Next Tasks
 - The header scanner is heuristic-based; consider a C++ parser
 - Optionally add a standalone CLI generator to emit `src/reflection_entry_gen.cpp`
-  without invoking the full PlatformIO build pipeline
+ without invoking the full PlatformIO build pipeline
 
 
 ## [0.1.4] - 2025-09-21
@@ -431,15 +472,15 @@ Added to .hpp automatic macro configuration to handle additional edge cases
 
 ### Added
 - reflect_capi.cpp
-  - Backend link between C ABI -> C++ Koilo library
+ - Backend link between C ABI -> C++ Koilo library
 - reflect.h
-  - Header for C ABI/API
+ - Header for C ABI/API
 - tasks.json
-  - Task file for setting up header smoke test (unfinished)
-  - Task for initializing/setting up the python workspace/venv
-  - Task for updating the Koilo registry macros in all of the .hpp files
+ - Task file for setting up header smoke test (unfinished)
+ - Task for initializing/setting up the python workspace/venv
+ - Task for updating the Koilo registry macros in all of the .hpp files
 - BuildSharedReflectLib.py
-  - Working on build script for C ABI
+ - Working on build script for C ABI
 - KoiloEngine virtual environment with automatic configuration when called via task
 
 ### Changed
@@ -463,13 +504,13 @@ Automatic .hpp macro configuration
 
 ### Added
 - UpdateKoiloRegistry.py
-  - Automatically generate and link Koilo macro functions to initialize registry
+ - Automatically generate and link Koilo macro functions to initialize registry
 
 ### Changed
 - All .hpp files
-  - Now include base macro calls for registry initialization
-  - Overloaded functions not fixed, require manual tweaking
-  - Added reflect_macros.hpp include to all .hpp files
+ - Now include base macro calls for registry initialization
+ - Overloaded functions not fixed, require manual tweaking
+ - Added reflect_macros.hpp include to all .hpp files
 
 ### Next Tasks
 - Fix all overloaded functions, macro calls will fail due to overlap
@@ -480,32 +521,32 @@ Updated reflection for C++
 
 ### Added 
 - global_registry.hpp
-  - list of class description objects
+ - list of class description objects
 
 ### Changed
 - demangle.hpp
-  - Simplified
+ - Simplified
 - reflect_helpers.hpp
-  - Improved invokers
-  - Streamlined field and method searching
-  - Added Pretty printing for demangled strings for types/signatures/constructors
+ - Improved invokers
+ - Streamlined field and method searching
+ - Added Pretty printing for demangled strings for types/signatures/constructors
 - reflect_macros.hpp
-  - Streamlined
-  - Implemented via global registry
-  - Implemented constructor creation
+ - Streamlined
+ - Implemented via global registry
+ - Implemented constructor creation
 - reflect_make.hpp
-  - Major restructure
-  - Implemented custom type span creation
-  - Changed invokers to use box return and new apply tuple functions
-  - Simplfied method/static methods/const methods
+ - Major restructure
+ - Implemented custom type span creation
+ - Changed invokers to use box return and new apply tuple functions
+ - Simplfied method/static methods/const methods
 
 ### Removed
 - reflectable.hpp
-  - No longer necessary with new implementation
+ - No longer necessary with new implementation
 
 ### Next Tasks
 - Implement UpdateKoiloRegistry.py to automatically configure C++ headers for new registry macros 
-  - Pay attention to ignoring operators/etc
+ - Pay attention to ignoring operators/etc
 - Implmement koilo_lua
 - Implement koilo_capi/reflect_capi (cpp mapping side)
 - Implement koilo_platform for library static/library linking for runtime initialization via capi on mcus and posix
@@ -516,19 +557,19 @@ First working end-to-end reflection pipeline: discover -> access -> invoke.
 
 ### Added
 - registry.hpp
-  - Define FieldDecl, MethodDesc, FieldList, MethodList
-  - Add FieldAccess helpers for safe get/set
-  - Provide simple demangle wrapper for type names
+ - Define FieldDecl, MethodDesc, FieldList, MethodList
+ - Add FieldAccess helpers for safe get/set
+ - Provide simple demangle wrapper for type names
 - reflectable.hpp
-  - Base CRTP template Reflectable<T> with static Fields() and Methods() hooks
+ - Base CRTP template Reflectable<T> with static Fields() and Methods() hooks
 - reflect_make.hpp
-  - Generic helpers (make_field, make_method, make_smethod)
-  - Type-safe argument unpacking & return boxing (works for void + value returns)
-  - Removes need for N-arg boilerplate macros
+ - Generic helpers (make_field, make_method, make_smethod)
+ - Type-safe argument unpacking & return boxing (works for void + value returns)
+ - Removes need for N-arg boilerplate macros
 - reflect_macros.hpp
-  - Macros KL_FIELD, KL_METHOD, KL_SMETHOD as thin sugar over make_*
-  - KL_BEGIN_FIELDS/METHODS & KL_END_FIELDS/METHODS for static arrays
-  - Simplified and future-proof (handles const/non-const, static, multiple args)
+ - Macros KL_FIELD, KL_METHOD, KL_SMETHOD as thin sugar over make_*
+ - KL_BEGIN_FIELDS/METHODS & KL_END_FIELDS/METHODS for static arrays
+ - Simplified and future-proof (handles const/non-const, static, multiple args)
 
 ### Changed
 - Updated RGBColor to declare reflected fields (R, G, B) and methods (Scale, Add, HueShift, ToString, InterpolateColors)
@@ -536,10 +577,10 @@ First working end-to-end reflection pipeline: discover -> access -> invoke.
 
 ### Testing
 - registry_test.cpp:
-  - Enumerates fields with demangled type names
-  - Dynamically reads/writes fields (R, G, B)
-  - Dynamically invokes methods (Add, Scale, HueShift, ToString, InterpolateColors)
-  - Prints expected round-trip values
+ - Enumerates fields with demangled type names
+ - Dynamically reads/writes fields (R, G, B)
+ - Dynamically invokes methods (Add, Scale, HueShift, ToString, InterpolateColors)
+ - Prints expected round-trip values
 
 
 ## [0.1.0] - 2025-08-18
@@ -677,7 +718,7 @@ Building out and decoupling functionality
 - Material shaders
 - Make ray trace function to replace rasterize
 - Split effect from scene and add to compositor
-  - Render post
+ - Render post
 
 
 ## [0.0.2] - 2025-06-18
@@ -687,8 +728,8 @@ Building out and decoupling functionality
 ### Added
 - GitHub markdowns for issues/funding/pr templates/contributing/etc
 - Importing rendering and rasterizing backend from ProtoTracer
-    - Upper Camel Case files are unconverted
-    - Empty files are in-progress
+ - Upper Camel Case files are unconverted
+ - Empty files are in-progress
 - Change Log
  
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ option(KOILO_ENABLE_AI "Build AI subsystem (pathfinding, behavior trees)" ON)
 option(KOILO_ENABLE_AUDIO "Build audio subsystem (SDL3 audio)" ON)
 option(KOILO_ENABLE_PARTICLES "Build particle subsystem" ON)
 option(KOILO_USE_VULKAN "Build Vulkan render backend and compile SPIR-V shaders" ON)
-option(KOILO_USE_OPENGL "Build OpenGL render backend" OFF)
+option(KOILO_USE_OPENGL "Build OpenGL render backend" ON)
 set(KL_UNITY_DIR ${CMAKE_SOURCE_DIR}/external/unity CACHE PATH "Path to Unity test framework")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -57,13 +57,11 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # Generation custom commands / targets
 add_custom_command(
   OUTPUT ${KL_GEN_DIR}/koilo/koiloall.hpp
-  BYPRODUCTS ${KL_GEN_DIR}/.koilo_reflect_cache.json
   COMMAND ${CMAKE_COMMAND} -E make_directory ${KL_GEN_DIR}/koilo
   COMMAND Python3::Interpreter ${KL_SCRIPTS_DIR}/generatekoiloall.py --root ${CMAKE_SOURCE_DIR}/engine/koilo --output ${KL_GEN_DIR}/koilo/koiloall.hpp
-  COMMAND Python3::Interpreter ${KL_SCRIPTS_DIR}/updatekoiloregistry.py --root ${CMAKE_SOURCE_DIR}/engine/koilo --write --cache-file ${KL_GEN_DIR}/.koilo_reflect_cache.json
-  DEPENDS ${KL_SCRIPTS_DIR}/generatekoiloall.py ${KL_SCRIPTS_DIR}/updatekoiloregistry.py ${KL_SCRIPTS_DIR}/consoleoutput.py
+  DEPENDS ${KL_SCRIPTS_DIR}/generatekoiloall.py ${KL_SCRIPTS_DIR}/consoleoutput.py
   WORKING_DIRECTORY ${KL_SCRIPTS_DIR}
-  COMMENT "Generating reflection umbrella header and Koilo registry cache"
+  COMMENT "Generating reflection umbrella header (koiloall.hpp)"
   VERBATIM
 )
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ CONFIG=${CONFIG:-Release}
 if command -v ninja &> /dev/null && [ -z "${GENERATOR:-}" ]; then
   GENERATOR="Ninja"
 else
-  GENERATOR=${GENERATOR:-Unix Makefiles}
+  GENERATOR=${GENERATOR:-"Unix Makefiles"}
 fi
 
 # Detect number of CPU cores for parallel compilation
@@ -35,35 +35,87 @@ fi
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
+
+# ---- Backend / feature flags (defaults match CMakeLists.txt) --------
+VULKAN=${VULKAN:-ON}
+OPENGL=${OPENGL:-ON}
+AI=${AI:-ON}
+AUDIO=${AUDIO:-ON}
+PARTICLES=${PARTICLES:-ON}
+
+# Parse flags from any position in the argument list
+POSITIONAL_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-vulkan)   VULKAN=OFF ;;
+    --no-opengl)   OPENGL=OFF ;;
+    --no-ai)       AI=OFF ;;
+    --no-audio)    AUDIO=OFF ;;
+    --no-particles) PARTICLES=OFF ;;
+    --vulkan)      VULKAN=ON ;;
+    --opengl)      OPENGL=ON ;;
+    --software-only) VULKAN=OFF; OPENGL=OFF ;;
+    --skip-ns)     export SKIP_NAMESPACE_CHECK=1 ;;
+    --debug)       CONFIG=Debug ;;
+    --release)     CONFIG=Release ;;
+    --help|-h)     POSITIONAL_ARGS+=("help") ;;
+    *)             POSITIONAL_ARGS+=("$arg") ;;
+  esac
+done
+set -- "${POSITIONAL_ARGS[@]+"${POSITIONAL_ARGS[@]}"}"
 
 usage() {
   cat <<EOF
 KoiloEngine unified build helper
-Usage: $0 [command]
+Usage: $(basename "$0") [command] [flags...]
+
 Commands:
-  configure         Run CMake configure step
+  all               Build all default targets (default command)
+  configure         Run CMake configure step only
   registry          Regenerate reflection umbrella and registry cache
   test-skeletons    Generate test skeletons for all untested classes
   namespace-check   Check for namespace violations (read-only)
-  core              Build koilo_core
+  core              Build koilo_core library
   reflect           Build koilo_reflect (implies generation)
-  tests             Build and run all C++ tests (Unity + script language tests)
-  headercheck       Build header smoke tests (compile all headers individually)
-  all               Build all default targets (includes namespace check)
-  clean             Remove build directory
+  tests             Build and run all C++ tests
+  headercheck       Build header smoke tests
   ctest             Run ctest in build directory
-Env vars:
-  CONFIG=Debug|Release (default Release)
-  GENERATOR=... CMake generator name (auto-detect Ninja or Unix Makefiles)
-  NUM_JOBS=N Number of parallel jobs (default: detected CPU cores: ${NUM_CORES})
-  SKIP_NAMESPACE_CHECK=1  Skip namespace validation
-  CMAKE_CXX_COMPILER_LAUNCHER=ccache  Use ccache (auto-detected if available)
+  clean             Remove build directory
+
+Flags:
+  --no-vulkan       Disable Vulkan backend
+  --no-opengl       Disable OpenGL backend
+  --software-only   Disable both Vulkan and OpenGL (software renderer only)
+  --vulkan          Enable Vulkan backend (default)
+  --opengl          Enable OpenGL backend (default)
+  --no-ai           Disable AI subsystem
+  --no-audio        Disable audio subsystem
+  --no-particles    Disable particle subsystem
+  --skip-ns         Skip namespace validation
+  --debug           Build in Debug mode
+  --release         Build in Release mode (default)
+  -h, --help        Show this help
+
+Environment variables:
+  CONFIG=Debug|Release        Build type (default: Release)
+  GENERATOR=...               CMake generator (default: auto-detect Ninja)
+  NUM_JOBS=N                  Parallel jobs (default: ${NUM_CORES} cores)
+  SKIP_NAMESPACE_CHECK=1      Skip namespace validation
+  VULKAN=ON|OFF               Vulkan backend (default: ON)
+  OPENGL=ON|OFF               OpenGL backend (default: ON)
 
 Current settings:
-  Generator: ${GENERATOR}
-  Parallel jobs: ${NUM_JOBS}
-  Compiler launcher: ${CMAKE_CXX_COMPILER_LAUNCHER:-none}
+  Build type:  ${CONFIG}
+  Generator:   ${GENERATOR}
+  Jobs:        ${NUM_JOBS}
+  ccache:      ${CMAKE_CXX_COMPILER_LAUNCHER:-none}
+  Vulkan:      ${VULKAN}
+  OpenGL:      ${OPENGL}
+  AI:          ${AI}
+  Audio:       ${AUDIO}
+  Particles:   ${PARTICLES}
 EOF
 }
 
@@ -72,7 +124,7 @@ check_namespace() {
     echo -e "${YELLOW}Skipping namespace check (SKIP_NAMESPACE_CHECK=1)${NC}"
     return 0
   fi
-  
+
   echo -e "${GREEN}Checking namespace usage...${NC}"
   if python3 "${ROOT_DIR}/scripts/checknamespace.py" --check > /dev/null 2>&1; then
     echo -e "${GREEN}All classes use koilo namespace${NC}"
@@ -80,26 +132,38 @@ check_namespace() {
   else
     echo -e "${RED}Namespace violations found!${NC}"
     echo -e "${YELLOW}Run: python3 scripts/checknamespace.py --check${NC}"
-    echo -e "${YELLOW}To see violations in detail.${NC}"
-    echo ""
-    echo -e "${YELLOW}To build anyway, use: SKIP_NAMESPACE_CHECK=1 ./build.sh${NC}"
+    echo -e "${YELLOW}To build anyway: ./build.sh --skip-ns${NC}"
     return 1
   fi
 }
 
 cmake_configure() {
+  local extra_args=("$@")
   mkdir -p "${BUILD_DIR}"
-  cmake -S "${ROOT_DIR}" -B "${BUILD_DIR}" -G "${GENERATOR}" -DCMAKE_BUILD_TYPE="${CONFIG}" "$@"
+  echo -e "${CYAN}Configuring: Vulkan=${VULKAN}  OpenGL=${OPENGL}  AI=${AI}  Audio=${AUDIO}  Particles=${PARTICLES}${NC}"
+  cmake -S "${ROOT_DIR}" -B "${BUILD_DIR}" -G "${GENERATOR}" \
+    -DCMAKE_BUILD_TYPE="${CONFIG}" \
+    -DKOILO_USE_VULKAN="${VULKAN}" \
+    -DKOILO_USE_OPENGL="${OPENGL}" \
+    -DKOILO_ENABLE_AI="${AI}" \
+    -DKOILO_ENABLE_AUDIO="${AUDIO}" \
+    -DKOILO_ENABLE_PARTICLES="${PARTICLES}" \
+    "${extra_args[@]+"${extra_args[@]}"}"
 }
 
 cmake_build() {
-  # Use parallel compilation with detected core count
   if [ "$GENERATOR" = "Ninja" ]; then
-    # Ninja handles parallelism automatically based on load
     cmake --build "${BUILD_DIR}" --config "${CONFIG}" --target "$@"
   else
-    # Make needs explicit -j flag
     cmake --build "${BUILD_DIR}" --config "${CONFIG}" --parallel "${NUM_JOBS}" --target "$@"
+  fi
+}
+
+cmake_build_all() {
+  if [ "$GENERATOR" = "Ninja" ]; then
+    cmake --build "${BUILD_DIR}" --config "${CONFIG}"
+  else
+    cmake --build "${BUILD_DIR}" --config "${CONFIG}" --parallel "${NUM_JOBS}"
   fi
 }
 
@@ -125,7 +189,9 @@ case "$cmd" in
     cmake_configure ; cmake_build koilo_reflect ;;
   tests)
     check_namespace
-    cmake_configure -DKL_BUILD_TESTS=ON ; cmake_build koilo_tests koilo_script_language_tests ; ctest --test-dir "${BUILD_DIR}" --output-on-failure ;;
+    cmake_configure -DKL_BUILD_TESTS=ON
+    cmake_build koilo_tests koilo_script_language_tests
+    ctest --test-dir "${BUILD_DIR}" --output-on-failure ;;
   headercheck)
     check_namespace
     cmake_configure ; cmake_build koilo_headercheck ;;
@@ -133,13 +199,15 @@ case "$cmd" in
     ctest --test-dir "${BUILD_DIR}" --output-on-failure ;;
   all)
     check_namespace
-    if [ "$GENERATOR" = "Ninja" ]; then
-      cmake_configure ; cmake --build "${BUILD_DIR}" --config "${CONFIG}"
-    else
-      cmake_configure ; cmake --build "${BUILD_DIR}" --config "${CONFIG}" --parallel "${NUM_JOBS}"
-    fi ;;
+    cmake_configure
+    cmake_build_all ;;
   clean)
+    echo -e "${YELLOW}Removing ${BUILD_DIR}${NC}"
     rm -rf "${BUILD_DIR}" ;;
+  help)
+    usage ;;
   *)
-    usage; exit 1 ;;
+    echo -e "${RED}Unknown command: ${cmd}${NC}"
+    usage
+    exit 1 ;;
 esac

--- a/engine/koilo/kernel/cvar/cvar_system.hpp
+++ b/engine/koilo/kernel/cvar/cvar_system.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <functional>
 #include <vector>
+#include "../../registry/reflect_macros.hpp"
 
 namespace koilo {
 
@@ -127,6 +128,22 @@ public:
 
 private:
     CVarParameter* param_;
+
+    KL_BEGIN_FIELDS(AutoCVar_Int)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(AutoCVar_Int)
+        KL_METHOD_AUTO(AutoCVar_Int, Get, "Get"),
+        KL_METHOD_AUTO(AutoCVar_Int, Set, "Set"),
+        KL_METHOD_AUTO(AutoCVar_Int, GetParam, "Get param"),
+        KL_METHOD_AUTO(AutoCVar_Int, OnChanged, "On changed")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(AutoCVar_Int)
+        KL_CTOR(AutoCVar_Int, const char*, const char*, int32_t, CVarFlags)
+    KL_END_DESCRIBE(AutoCVar_Int)
+
 };
 
 /// Float CVar.
@@ -143,6 +160,22 @@ public:
 
 private:
     CVarParameter* param_;
+
+    KL_BEGIN_FIELDS(AutoCVar_Float)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(AutoCVar_Float)
+        KL_METHOD_AUTO(AutoCVar_Float, Get, "Get"),
+        KL_METHOD_AUTO(AutoCVar_Float, Set, "Set"),
+        KL_METHOD_AUTO(AutoCVar_Float, GetParam, "Get param"),
+        KL_METHOD_AUTO(AutoCVar_Float, OnChanged, "On changed")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(AutoCVar_Float)
+        KL_CTOR(AutoCVar_Float, const char*, const char*, float, CVarFlags)
+    KL_END_DESCRIBE(AutoCVar_Float)
+
 };
 
 /// Bool CVar.
@@ -159,6 +192,22 @@ public:
 
 private:
     CVarParameter* param_;
+
+    KL_BEGIN_FIELDS(AutoCVar_Bool)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(AutoCVar_Bool)
+        KL_METHOD_AUTO(AutoCVar_Bool, Get, "Get"),
+        KL_METHOD_AUTO(AutoCVar_Bool, Set, "Set"),
+        KL_METHOD_AUTO(AutoCVar_Bool, GetParam, "Get param"),
+        KL_METHOD_AUTO(AutoCVar_Bool, OnChanged, "On changed")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(AutoCVar_Bool)
+        KL_CTOR(AutoCVar_Bool, const char*, const char*, bool, CVarFlags)
+    KL_END_DESCRIBE(AutoCVar_Bool)
+
 };
 
 /// String CVar.
@@ -175,6 +224,22 @@ public:
 
 private:
     CVarParameter* param_;
+
+    KL_BEGIN_FIELDS(AutoCVar_String)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(AutoCVar_String)
+        KL_METHOD_AUTO(AutoCVar_String, Get, "Get"),
+        KL_METHOD_AUTO(AutoCVar_String, Set, "Set"),
+        KL_METHOD_AUTO(AutoCVar_String, GetParam, "Get param"),
+        KL_METHOD_AUTO(AutoCVar_String, OnChanged, "On changed")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(AutoCVar_String)
+        KL_CTOR(AutoCVar_String, const char*, const char*, const char*, CVarFlags)
+    KL_END_DESCRIBE(AutoCVar_String)
+
 };
 
 } // namespace koilo

--- a/engine/koilo/koiloall.hpp
+++ b/engine/koilo/koiloall.hpp
@@ -85,13 +85,19 @@
 #include <koilo/kernel/asset/asset_job_queue.hpp>
 #include <koilo/kernel/asset/asset_manifest.hpp>
 #include <koilo/kernel/capabilities.hpp>
+#include <koilo/kernel/config/config_store.hpp>
 #include <koilo/kernel/console/command_registry.hpp>
 #include <koilo/kernel/console/console_commands.hpp>
 #include <koilo/kernel/console/console_module.hpp>
 #include <koilo/kernel/console/console_result.hpp>
 #include <koilo/kernel/console/console_session.hpp>
 #include <koilo/kernel/console/console_socket.hpp>
+#include <koilo/kernel/console/event_bridge.hpp>
+#include <koilo/kernel/cvar/cvar_system.hpp>
+#include <koilo/kernel/debug_overlay.hpp>
 #include <koilo/kernel/kernel.hpp>
+#include <koilo/kernel/logging/log.hpp>
+#include <koilo/kernel/logging/log_system.hpp>
 #include <koilo/kernel/memory/allocation_tag.hpp>
 #include <koilo/kernel/message_bus.hpp>
 #include <koilo/kernel/module.hpp>
@@ -99,6 +105,8 @@
 #include <koilo/kernel/module_loader.hpp>
 #include <koilo/kernel/module_manager.hpp>
 #include <koilo/kernel/register_services.hpp>
+#include <koilo/kernel/sim_cvars.hpp>
+#include <koilo/kernel/thread_pool.hpp>
 #include <koilo/ksl/ksl.hpp>
 #include <koilo/ksl/ksl_elf_types.hpp>
 #include <koilo/ksl/ksl_macros.hpp>
@@ -142,13 +150,9 @@
 #include <koilo/systems/audio/audiosource.hpp>
 #include <koilo/systems/audio/script_audio_manager.hpp>
 #include <koilo/systems/display/backends/embedded/hub75backend.hpp>
-#ifdef KL_HAVE_OPENGL_BACKEND
 #include <koilo/systems/display/backends/gpu/openglbackend.hpp>
-#endif
 #include <koilo/systems/display/backends/gpu/sdl3backend.hpp>
-#ifdef KL_HAVE_VULKAN_BACKEND
 #include <koilo/systems/display/backends/gpu/vulkanbackend.hpp>
-#endif
 #include <koilo/systems/display/backends/nullbackend.hpp>
 #include <koilo/systems/display/displayinfo.hpp>
 #include <koilo/systems/display/displaymanager.hpp>
@@ -161,11 +165,13 @@
 #include <koilo/systems/ecs/entitymanager.hpp>
 #include <koilo/systems/ecs/script_entity_manager.hpp>
 #include <koilo/systems/input/gamepad.hpp>
+#include <koilo/systems/input/input_module.hpp>
 #include <koilo/systems/input/inputmanager.hpp>
 #include <koilo/systems/input/keyboard.hpp>
 #include <koilo/systems/input/keycodes.hpp>
 #include <koilo/systems/input/mouse.hpp>
 #include <koilo/systems/particles/particle.hpp>
+#include <koilo/systems/particles/particle_module.hpp>
 #include <koilo/systems/particles/particleemitter.hpp>
 #include <koilo/systems/particles/particlesystem.hpp>
 #include <koilo/systems/physics/boundarymotionsimulator.hpp>
@@ -186,18 +192,24 @@
 #include <koilo/systems/render/canvas2d.hpp>
 #include <koilo/systems/render/core/pixel.hpp>
 #include <koilo/systems/render/core/pixelgroup.hpp>
-#ifdef KL_HAVE_OPENGL_BACKEND
 #include <koilo/systems/render/gl/opengl_render_backend.hpp>
-#endif
 #include <koilo/systems/render/gl/render_backend_factory.hpp>
 #include <koilo/systems/render/gl/software_render_backend.hpp>
 #include <koilo/systems/render/material/imaterial.hpp>
 #include <koilo/systems/render/material/implementations/kslmaterial.hpp>
+#include <koilo/systems/render/pipeline/material_binder.hpp>
+#include <koilo/systems/render/pipeline/mesh_cache.hpp>
+#include <koilo/systems/render/pipeline/render_pipeline.hpp>
+#include <koilo/systems/render/pipeline/texture_cache.hpp>
 #include <koilo/systems/render/raster/helpers/rastertriangle2d.hpp>
 #include <koilo/systems/render/raster/helpers/rastertriangle3d.hpp>
 #include <koilo/systems/render/raster/rasterizer.hpp>
 #include <koilo/systems/render/ray/rayintersection.hpp>
 #include <koilo/systems/render/ray/raytracer.hpp>
+#include <koilo/systems/render/render_cvars.hpp>
+#include <koilo/systems/render/render_module.hpp>
+#include <koilo/systems/render/rhi/rhi_caps.hpp>
+#include <koilo/systems/render/rhi/rhi_types.hpp>
 #include <koilo/systems/render/shader/ishader.hpp>
 #include <koilo/systems/render/sky/sky.hpp>
 #include <koilo/systems/render/vk/vulkan_render_backend.hpp>
@@ -224,6 +236,7 @@
 #include <koilo/systems/scene/morphablemesh.hpp>
 #include <koilo/systems/scene/primitivemesh.hpp>
 #include <koilo/systems/scene/scene.hpp>
+#include <koilo/systems/scene/scene_module.hpp>
 #include <koilo/systems/scene/scenenode.hpp>
 #include <koilo/systems/scene/sprite.hpp>
 #include <koilo/systems/world/level.hpp>

--- a/engine/koilo/ksl/ksl_macros.hpp
+++ b/engine/koilo/ksl/ksl_macros.hpp
@@ -47,3 +47,39 @@
     static ksl::ParamList Params() {                                        \
         return ksl::ParamList{ nullptr, 0 };                                \
     }
+
+// -- Shader metadata (render hints, etc.) ----------------------------
+//
+// Shaders can declare arbitrary key-value metadata that the engine reads
+// at load time.  This is used for render hints (depthTest, cullMode, etc.)
+// and is extensible to any future shader-level property.
+//
+// struct MySkyShader : public ksl::Shader {
+//     KSL_META_BEGIN(MySkyShader)
+//         KSL_META_INT("depthTest",  0)
+//         KSL_META_INT("depthWrite", 0)
+//         KSL_META_INT("cullMode",   0)
+//     KSL_META_END
+// };
+
+#define KSL_META_BEGIN(CLASS)                                               \
+    static ksl::MetaList Meta() {                                           \
+        static const ksl::MetaEntry _meta[] = {
+
+#define KSL_META_INT(KEY, VAL)                                              \
+    ksl::MetaEntry{ KEY, ksl::MetaType::Int, { .intVal = (VAL) } },
+
+#define KSL_META_FLOAT(KEY, VAL)                                            \
+    ksl::MetaEntry{ KEY, ksl::MetaType::Float, { .floatVal = (VAL) } },
+
+#define KSL_META_END                                                        \
+        };                                                                  \
+        return ksl::MetaList{ _meta,                                        \
+            static_cast<int>(sizeof(_meta) / sizeof(_meta[0])) };           \
+    }
+
+// For shaders with no metadata (default render settings)
+#define KSL_NO_META                                                         \
+    static ksl::MetaList Meta() {                                           \
+        return ksl::MetaList{ nullptr, 0 };                                 \
+    }

--- a/engine/koilo/ksl/ksl_module.hpp
+++ b/engine/koilo/ksl/ksl_module.hpp
@@ -35,6 +35,18 @@ public:
 #endif
     }
 
+    /// True if GLSL source is available for RHI shader creation.
+    bool HasGLSLSource() const { return !glslFragSource_.empty(); }
+
+    /// True if the module can provide GPU shading (GL program or GLSL source).
+    bool HasShaderData() const { return HasGPU() || HasGLSLSource(); }
+
+    /// Retained GLSL fragment shader source (available on all platforms).
+    const std::string& GetGLSLFragmentSource() const { return glslFragSource_; }
+
+    /// Retained GLSL vertex shader source (available on all platforms).
+    const std::string& GetGLSLVertexSource() const { return glslVertSource_; }
+
     // Load .kso (ELF) for CPU shading - unified across all platforms
     bool LoadKSO(const std::string& path, const KSLSymbolTable& symbols) {
         // Read file into memory
@@ -71,18 +83,35 @@ public:
                 requiredAttribs_ = info->requiredAttribs;
             }
         }
+
+        // Resolve optional metadata (render hints etc.)
+        auto metaFn = elfLoader_.GetSymbol<KSLMetadataFn>("ksl_metadata");
+        if (metaFn) {
+            int count = 0;
+            const MetaEntry* entries = metaFn(&count);
+            if (entries && count > 0) {
+                metadata_.assign(entries, entries + count);
+            }
+        }
+
         return shadeFn_ != nullptr;
     }
 
-    // Load .glsl file and compile to GL program
+    // Load .glsl file and compile to GL program.
+    // Also retains GLSL source strings for RHI shader creation (Phase 17f).
     bool LoadGLSL(const std::string& path, const std::string& vertexSrc) {
-#ifdef KL_HAVE_OPENGL_BACKEND
         std::ifstream file(path);
         if (!file.is_open()) return false;
 
         std::stringstream ss;
         ss << file.rdbuf();
         std::string fragSrc = ss.str();
+
+        // Retain GLSL source for backend-agnostic shader creation via RHI
+        glslFragSource_ = fragSrc;
+        glslVertSource_ = vertexSrc;
+
+#ifdef KL_HAVE_OPENGL_BACKEND
 
         GLuint vs = CompileShader(GL_VERTEX_SHADER, vertexSrc.c_str());
         GLuint fs = CompileShader(GL_FRAGMENT_SHADER, fragSrc.c_str());
@@ -120,7 +149,9 @@ public:
 
         return true;
 #else
-        return false;
+        // No GL context available - GLSL source is retained for RHI
+        // shader creation but no GL program is compiled.
+        return !glslFragSource_.empty();
 #endif
     }
 
@@ -138,6 +169,27 @@ public:
     KSLShadeFn GetShadeFn() const { return shadeFn_; }
 
     uint8_t GetRequiredAttribs() const { return requiredAttribs_; }
+
+    /// @brief Return the metadata list loaded from the .kso module.
+    MetaList GetMetadata() const { return {metadata_.data(), static_cast<int>(metadata_.size())}; }
+
+    /// @brief Look up an integer metadata value by key. Returns fallback if not found.
+    int GetMetaInt(const char* key, int fallback = 0) const {
+        for (const auto& e : metadata_) {
+            if (e.type == MetaType::Int && std::strcmp(e.key, key) == 0)
+                return e.intVal;
+        }
+        return fallback;
+    }
+
+    /// @brief Look up a float metadata value by key. Returns fallback if not found.
+    float GetMetaFloat(const char* key, float fallback = 0.0f) const {
+        for (const auto& e : metadata_) {
+            if (e.type == MetaType::Float && std::strcmp(e.key, key) == 0)
+                return e.floatVal;
+        }
+        return fallback;
+    }
 
     ParamList GetParams() const {
         if (paramsFn_) {
@@ -189,6 +241,9 @@ public:
         setParamFn_ = nullptr;
         paramsFn_ = nullptr;
         requiredAttribs_ = SHADE_ATTRIB_ALL;
+        metadata_.clear();
+        glslFragSource_.clear();
+        glslVertSource_.clear();
     }
 
 private:
@@ -222,6 +277,13 @@ private:
     KSLShadeFn    shadeFn_ = nullptr;
     KSLParamsFn   paramsFn_ = nullptr;
     uint8_t       requiredAttribs_ = SHADE_ATTRIB_ALL;
+
+    // Shader metadata (render hints, etc.) loaded from .kso
+    std::vector<MetaEntry> metadata_;
+
+    // GLSL source retention for backend-agnostic RHI shader creation (Phase 17f)
+    std::string glslFragSource_;
+    std::string glslVertSource_;
 
     // GPU (GL program)
 #ifdef KL_HAVE_OPENGL_BACKEND

--- a/engine/koilo/ksl/ksl_registry.hpp
+++ b/engine/koilo/ksl/ksl_registry.hpp
@@ -35,14 +35,19 @@ public:
 
         if (!fs::exists(dir) || !fs::is_directory(dir)) return 0;
 
+        // Retain vertex shader source for RHI shader creation (Phase 17f)
+        if (!vertexShaderSrc.empty()) {
+            vertexShaderSource_ = vertexShaderSrc;
+        }
+
         auto endsWith = [](const std::string& s, const std::string& suffix) {
             return s.size() >= suffix.size() &&
                    s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
         };
 
-        // Try loading uber-shader first
-        bool hasUber = false;
+        // Try loading uber-shader first (GL only)
 #ifdef KL_HAVE_OPENGL_BACKEND
+        bool hasUber = false;
         std::string uberGlsl = dir + "/uber.glsl";
         std::string uberIds  = dir + "/uber_ids.txt";
         if (!vertexShaderSrc.empty() && fs::exists(uberGlsl) && fs::exists(uberIds)) {
@@ -102,6 +107,11 @@ public:
                     hasGPU = true;
                 }
             } else if (fs::exists(glslPath) && !vertexShaderSrc.empty()) {
+                hasGPU = mod->LoadGLSL(glslPath, vertexShaderSrc);
+            }
+#else
+            // No GL context - load GLSL for source retention (RHI shader creation)
+            if (fs::exists(glslPath) && !vertexShaderSrc.empty()) {
                 hasGPU = mod->LoadGLSL(glslPath, vertexShaderSrc);
             }
 #endif
@@ -186,6 +196,12 @@ public:
     /** Check if SPIR-V data is loaded. */
     bool HasSPIRV() const { return !spirvData_.empty() && !vertexSPIRV_.empty(); }
 
+    /** Get retained GLSL vertex shader source (for RHI shader creation). */
+    const std::string& GetVertexShaderSource() const { return vertexShaderSource_; }
+
+    /** Check if GLSL source is available for RHI shader creation. */
+    bool HasGLSLSources() const { return !vertexShaderSource_.empty(); }
+
     /** Get list of loaded SPIR-V shader names. */
     std::vector<std::string> ListSPIRVShaders() const {
         std::vector<std::string> names;
@@ -239,6 +255,7 @@ public:
         modules_.clear();
         vertexSPIRV_.clear();
         spirvData_.clear();
+        vertexShaderSource_.clear();
     }
 
 private:
@@ -251,6 +268,9 @@ private:
     // SPIR-V bytecode storage (loaded but not consumed until Vulkan backend creates pipelines)
     std::vector<uint32_t> vertexSPIRV_;
     std::unordered_map<std::string, std::vector<uint32_t>> spirvData_;
+
+    // GLSL source retention for RHI shader creation (Phase 17f)
+    std::string vertexShaderSource_;
 
     /** Read a binary file as uint32_t words (SPIR-V format). */
     static std::vector<uint32_t> ReadBinaryFile(const std::string& path) {

--- a/engine/koilo/ksl/ksl_shader.hpp
+++ b/engine/koilo/ksl/ksl_shader.hpp
@@ -124,6 +124,27 @@ enum ShadeAttrib : uint8_t {
     SHADE_ATTRIB_ALL     = 0xFF
 };
 
+// --- Shader metadata (key-value pairs for render hints etc.) ---
+
+/// @brief Type tag for a metadata entry value.
+enum class MetaType : uint8_t { Int, Float };
+
+/// @brief Single key-value metadata entry declared by a shader.
+struct MetaEntry {
+    const char* key;
+    MetaType    type;
+    union {
+        int32_t intVal;
+        float   floatVal;
+    };
+};
+
+/// @brief List of metadata entries returned by a shader module.
+struct MetaList {
+    const MetaEntry* entries;
+    int              count;
+};
+
 // --- C ABI for .so modules ---
 
 struct KSLShaderInfo {
@@ -140,6 +161,7 @@ using KSLSetParamFn   = void (*)(void*, const char*, const void*, int, int);
 using KSLShadeFn      = vec4 (*)(void*, const ShadeInput*);
 using KSLInfoFn       = const KSLShaderInfo* (*)();
 using KSLParamsFn     = const ParamDecl* (*)(int*);
+using KSLMetadataFn   = const MetaEntry* (*)(int*);
 
 } // namespace ksl
 

--- a/engine/koilo/platform/sdl3_host.hpp
+++ b/engine/koilo/platform/sdl3_host.hpp
@@ -48,6 +48,7 @@
 #ifdef KL_HAVE_VULKAN_BACKEND
 #include <koilo/systems/display/backends/gpu/vulkanbackend.hpp>
 #endif
+#include <koilo/systems/display/backends/gpu/sdl3backend.hpp>
 #include <koilo/systems/display/framebuffer.hpp>
 #include <koilo/systems/render/gl/render_backend_factory.hpp>
 #include <koilo/systems/profiling/performanceprofiler.hpp>
@@ -76,7 +77,8 @@ struct SDL3Host {
     bool forceSoftware   = false;
     bool forceUncapped   = false;
     bool enableConsole   = false;
-    bool preferVulkan    = false;
+    bool preferVulkan    = true;
+    bool preferOpenGL    = false;
     int  profilerInterval = 120;  // Print report every N frames (0 = never)
     const char* modulesDir = nullptr;
     std::atomic<bool>* externalStop = nullptr;  // If set, RunLoop exits when *externalStop == false
@@ -163,7 +165,7 @@ private:
         IGPUDisplayBackend* gpuDisplayPtr = nullptr;
 #ifdef KL_HAVE_VULKAN_BACKEND
         VulkanBackend* vkDisplay = nullptr;
-        if (preferVulkan) {
+        if (preferVulkan && !preferOpenGL) {
             auto vk = std::make_unique<VulkanBackend>(
                 static_cast<uint32_t>(winW), static_cast<uint32_t>(winH),
                 std::string(windowTitle), false, true);
@@ -176,24 +178,55 @@ private:
             }
         }
 #endif
+#ifdef KL_HAVE_OPENGL_BACKEND
+        if (!displayOwner && !forceSoftware) {
+            auto gl = std::make_unique<OpenGLBackend>(winW, winH, windowTitle, false, true);
+            if (gl->Initialize()) {
+                gpuDisplayPtr = gl.get();
+                displayOwner = std::move(gl);
+            } else {
+                KL_WARN("SDL3Host", "OpenGL init failed, falling back to software");
+            }
+        }
+#endif
+        // Pure software fallback: SDL3Backend provides a window without OpenGL/Vulkan
+        SDL3Backend* sdlSoftwareDisplay = nullptr;
         if (!displayOwner) {
 #ifdef KL_HAVE_OPENGL_BACKEND
+            // Use OpenGL as a display surface for software rendering
             auto gl = std::make_unique<OpenGLBackend>(winW, winH, windowTitle, false, true);
             if (!gl->Initialize()) {
-                KL_ERR("SDL3Host", "Failed to initialize OpenGL display backend");
+                KL_ERR("SDL3Host", "Failed to initialize any display backend");
                 return 1;
             }
             gpuDisplayPtr = gl.get();
             displayOwner = std::move(gl);
 #else
-            KL_ERR("SDL3Host", "No display backend available");
-            return 1;
+            // No GPU backend -- use pure SDL3 software display
+            auto sdl = std::make_unique<SDL3Backend>(
+                static_cast<uint32_t>(winW), static_cast<uint32_t>(winH),
+                std::string(windowTitle), false, true);
+            if (!sdl->Initialize()) {
+                KL_ERR("SDL3Host", "Failed to initialize SDL3 software display");
+                return 1;
+            }
+            sdlSoftwareDisplay = sdl.get();
+            displayOwner = std::move(sdl);
+            forceSoftware = true;
+            KL_LOG("SDL3Host", "Using pure SDL3 software display");
 #endif
         }
-        IGPUDisplayBackend& gpuDisplay = *gpuDisplayPtr;
-        if (enableVSync) cvar_r_vsync.Set(true);
-        gpuDisplay.SetVSyncEnabled(cvar_r_vsync.Get());
-        if (forceSoftware) gpuDisplay.SetNearestFiltering(true);
+        IGPUDisplayBackend* gpuDisplayRaw = gpuDisplayPtr;
+        if (gpuDisplayRaw) {
+            if (enableVSync) cvar_r_vsync.Set(true);
+            gpuDisplayRaw->SetVSyncEnabled(cvar_r_vsync.Get());
+            if (forceSoftware) gpuDisplayRaw->SetNearestFiltering(true);
+        } else if (sdlSoftwareDisplay) {
+            if (enableVSync) {
+                cvar_r_vsync.Set(true);
+                sdlSoftwareDisplay->SetVSyncEnabled(true);
+            }
+        }
 
         // Select render backend
         if (!forceSoftware) {
@@ -217,7 +250,6 @@ private:
         // Frame state
         std::vector<Color888> fb(pixW * pixH);
         bool   running    = true;
-        bool   firstFrame = true;
         int    frameNum   = 0;
         uint64_t freq     = SDL_GetPerformanceFrequency();
         uint64_t lastTick = SDL_GetPerformanceCounter();
@@ -308,8 +340,8 @@ private:
             kernel.BeginFrame();
 
             if (gpuBackend) {
-                if (!firstFrame) gpuDisplay.SwapOnly();
-                firstFrame = false;
+                // Begin GPU frame (acquires swapchain, starts cmd buffer)
+                gpuBackend->PrepareFrame();
 
                 // Simulation pause: skip tick unless stepping
                 bool simPaused = cvar_sim_pause.Get();
@@ -324,7 +356,6 @@ private:
                 }
 
                 engine.RenderFrameGPU();
-                gpuDisplay.PrepareDefaultFramebuffer(winW, winH);
                 gpuBackend->BlitToScreen(winW, winH);
                 gpuBackend->CompositeCanvasOverlays(winW, winH);
 #ifdef KL_HAVE_VULKAN_BACKEND
@@ -344,6 +375,17 @@ private:
                 {
                     engine.RenderUIOverlay(winW, winH, dt);
                 }
+
+                // End GPU frame (submits cmd buffer + presents)
+                gpuBackend->FinishFrame();
+
+                // OpenGL GPU backends render to the default framebuffer but
+                // don't own the window swap.  Vulkan manages its own present
+                // inside FinishFrame, so only swap for non-Vulkan displays.
+#ifdef KL_HAVE_VULKAN_BACKEND
+                if (!vkDisplay)
+#endif
+                    gpuDisplayRaw->SwapOnly();
             } else {
                 // Software render path
                 bool simPaused = cvar_sim_pause.Get();
@@ -362,8 +404,12 @@ private:
                 Framebuffer framebuffer(
                     reinterpret_cast<uint8_t*>(fb.data()),
                     pixW, pixH, PixelFormat::RGB888);
-                gpuDisplay.PresentNoSwap(framebuffer);
-                gpuDisplay.SwapOnly();
+                if (gpuDisplayRaw) {
+                    gpuDisplayRaw->PresentNoSwap(framebuffer);
+                    gpuDisplayRaw->SwapOnly();
+                } else if (sdlSoftwareDisplay) {
+                    sdlSoftwareDisplay->Present(framebuffer);
+                }
             }
 
             kernel.EndFrame();
@@ -450,8 +496,14 @@ private:
                 modulesDir = argv[++i];
             else if (std::strcmp(argv[i], "--console") == 0)
                 enableConsole = true;
-            else if (std::strcmp(argv[i], "--vulkan") == 0)
+            else if (std::strcmp(argv[i], "--vulkan") == 0) {
                 preferVulkan = true;
+                preferOpenGL = false;
+            }
+            else if (std::strcmp(argv[i], "--opengl") == 0) {
+                preferOpenGL = true;
+                preferVulkan = false;
+            }
         }
     }
 };

--- a/engine/koilo/systems/display/backends/embedded/hub75backend.hpp
+++ b/engine/koilo/systems/display/backends/embedded/hub75backend.hpp
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <koilo/systems/display/idisplaybackend.hpp>
-#include "../../../../registry/reflect_macros.hpp"
 
 namespace koilo {
 
@@ -67,6 +66,7 @@ struct HUB75Config {
           clk_pin(13), lat_pin(14), oe_pin(15),
           panelWidth(64), panelHeight(32), chainLength(1), scanPattern(0),
           brightness(128), colorDepth(8), refreshRate(60), _pad(0) {}
+
 } __attribute__((packed));
 
 /**
@@ -120,39 +120,6 @@ private:
     uint8_t ApplyGamma(uint8_t value) const;
     void BuildGammaTable();
     void SwapBuffers();
-
-    KL_BEGIN_FIELDS(HUB75Backend)
-        /* No reflected fields. */
-    KL_END_FIELDS
-
-    KL_BEGIN_METHODS(HUB75Backend)
-        KL_METHOD_AUTO(HUB75Backend, Shutdown, "Shutdown"),
-        KL_METHOD_AUTO(HUB75Backend, IsInitialized, "Is initialized"),
-        KL_METHOD_AUTO(HUB75Backend, GetInfo, "Get info"),
-        KL_METHOD_AUTO(HUB75Backend, HasCapability, "Has capability"),
-        KL_METHOD_AUTO(HUB75Backend, Present, "Present"),
-        KL_METHOD_AUTO(HUB75Backend, WaitVSync, "Wait vsync"),
-        KL_METHOD_AUTO(HUB75Backend, Clear, "Clear"),
-        KL_METHOD_AUTO(HUB75Backend, SetRefreshRate, "Set refresh rate"),
-        KL_METHOD_AUTO(HUB75Backend, SetOrientation, "Set orientation"),
-        KL_METHOD_AUTO(HUB75Backend, SetBrightness, "Set brightness"),
-        KL_METHOD_AUTO(HUB75Backend, SetVSyncEnabled, "Set vsync enabled"),
-        KL_METHOD_AUTO(HUB75Backend, GetColorDepth, "Get color depth"),
-        KL_METHOD_AUTO(HUB75Backend, SetGammaCorrectionEnabled, "Set gamma correction enabled"),
-        KL_METHOD_AUTO(HUB75Backend, IsGammaCorrectionEnabled, "Is gamma correction enabled"),
-        KL_METHOD_AUTO(HUB75Backend, SetScanPattern, "Set scan pattern"),
-        KL_METHOD_AUTO(HUB75Backend, GetConfig, "Get config")
-    KL_END_METHODS
-
-    // Reflection disabled - causes template issues with default parameters
-    // TODO: Fix reflection for default constructor parameters
-    /*
-    KL_BEGIN_DESCRIBE(HUB75Backend)
-        KL_CTOR(HUB75Backend, const HUB75Config& config),
-        KL_CTOR(HUB75Backend, uint16_t width, uint16_t height, uint8_t chainLength)
-    KL_END_DESCRIBE(HUB75Backend)
-    */
-
 };
 
 } // namespace koilo

--- a/engine/koilo/systems/display/backends/gpu/openglbackend.cpp
+++ b/engine/koilo/systems/display/backends/gpu/openglbackend.cpp
@@ -21,6 +21,9 @@ extern "C" {
 // to run before most other static initializers.
 __attribute__((constructor(101)))
 static void koilo_request_discrete_gpu() {
+    // Mesa PRIME: use discrete GPU via DRI
+    setenv("DRI_PRIME", "1", 0);
+    // NVIDIA proprietary PRIME: offload to discrete GPU
     setenv("__NV_PRIME_RENDER_OFFLOAD", "1", 0);
     setenv("__GLX_VENDOR_LIBRARY_NAME", "nvidia", 0);
 }

--- a/engine/koilo/systems/display/backends/gpu/vulkanbackend.hpp
+++ b/engine/koilo/systems/display/backends/gpu/vulkanbackend.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include "../../../../registry/reflect_macros.hpp"
 
 // Forward declarations
 struct SDL_Window;
@@ -65,6 +66,24 @@ struct VulkanGPUInfo {
     uint32_t    deviceID;
     bool        isDiscrete;
     uint64_t    vramBytes;
+
+    KL_BEGIN_FIELDS(VulkanGPUInfo)
+        KL_FIELD(VulkanGPUInfo, index, "Index", 0, 4294967295),
+        KL_FIELD(VulkanGPUInfo, name, "Name", 0, 0),
+        KL_FIELD(VulkanGPUInfo, vendorID, "Vendor id", 0, 4294967295),
+        KL_FIELD(VulkanGPUInfo, deviceID, "Device id", 0, 4294967295),
+        KL_FIELD(VulkanGPUInfo, isDiscrete, "Is discrete", 0, 1),
+        KL_FIELD(VulkanGPUInfo, vramBytes, "Vram bytes", 0, 18446744073709551615)
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(VulkanGPUInfo)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(VulkanGPUInfo)
+        /* No reflected ctors. */
+    KL_END_DESCRIBE(VulkanGPUInfo)
+
 };
 
 static constexpr int kMaxFramesInFlight = 2;
@@ -244,6 +263,49 @@ private:
 
     // Utility
     uint32_t FindMemoryType(uint32_t typeFilter, uint32_t properties);
+
+    KL_BEGIN_FIELDS(VulkanBackend)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(VulkanBackend)
+        KL_METHOD_AUTO(VulkanBackend, Shutdown, "Shutdown"),
+        KL_METHOD_AUTO(VulkanBackend, IsInitialized, "Is initialized"),
+        KL_METHOD_AUTO(VulkanBackend, GetInfo, "Get info"),
+        KL_METHOD_AUTO(VulkanBackend, HasCapability, "Has capability"),
+        KL_METHOD_AUTO(VulkanBackend, Present, "Present"),
+        KL_METHOD_AUTO(VulkanBackend, WaitVSync, "Wait vsync"),
+        KL_METHOD_AUTO(VulkanBackend, Clear, "Clear"),
+        KL_METHOD_AUTO(VulkanBackend, SetRefreshRate, "Set refresh rate"),
+        KL_METHOD_AUTO(VulkanBackend, SetOrientation, "Set orientation"),
+        KL_METHOD_AUTO(VulkanBackend, SetBrightness, "Set brightness"),
+        KL_METHOD_AUTO(VulkanBackend, SetVSyncEnabled, "Set vsync enabled"),
+        KL_METHOD_AUTO(VulkanBackend, PresentNoSwap, "Present no swap"),
+        KL_METHOD_AUTO(VulkanBackend, SetNearestFiltering, "Set nearest filtering"),
+        KL_METHOD_AUTO(VulkanBackend, PrepareDefaultFramebuffer, "Prepare default framebuffer"),
+        KL_METHOD_AUTO(VulkanBackend, GetSelectedGPUIndex, "Get selected gpuindex"),
+        KL_METHOD_AUTO(VulkanBackend, GetInstance, "Get instance"),
+        KL_METHOD_AUTO(VulkanBackend, GetPhysicalDevice, "Get physical device"),
+        KL_METHOD_AUTO(VulkanBackend, GetDevice, "Get device"),
+        KL_METHOD_AUTO(VulkanBackend, GetGraphicsQueue, "Get graphics queue"),
+        KL_METHOD_AUTO(VulkanBackend, GetGraphicsFamily, "Get graphics family"),
+        KL_METHOD_AUTO(VulkanBackend, GetRenderPass, "Get render pass"),
+        KL_METHOD_AUTO(VulkanBackend, GetSwapchainWidth, "Get swapchain width"),
+        KL_METHOD_AUTO(VulkanBackend, GetSwapchainHeight, "Get swapchain height"),
+        KL_METHOD_AUTO(VulkanBackend, GetSwapchainFormat, "Get swapchain format"),
+        KL_METHOD_AUTO(VulkanBackend, GetCurrentFrame, "Get current frame"),
+        KL_METHOD_AUTO(VulkanBackend, BeginFrame, "Begin frame"),
+        KL_METHOD_AUTO(VulkanBackend, BeginSwapchainRenderPass, "Begin swapchain render pass"),
+        KL_METHOD_AUTO(VulkanBackend, SetTitle, "Set title"),
+        KL_METHOD_AUTO(VulkanBackend, SetFullscreen, "Set fullscreen"),
+        KL_METHOD_AUTO(VulkanBackend, IsWindowOpen, "Is window open"),
+        KL_METHOD_AUTO(VulkanBackend, GetWindowSize, "Get window size")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(VulkanBackend)
+        KL_CTOR(VulkanBackend, uint32_t, uint32_t, const std::string&, bool, bool)
+    KL_END_DESCRIBE(VulkanBackend)
+
 };
 
 } // namespace koilo

--- a/engine/koilo/systems/render/gl/opengl_render_backend.cpp
+++ b/engine/koilo/systems/render/gl/opengl_render_backend.cpp
@@ -788,7 +788,10 @@ OpenGLRenderBackend::MeshCacheEntry& OpenGLRenderBackend::UploadMesh(Mesh* mesh)
         verts.push_back({p1.X, p1.Y, p1.Z, n.X, n.Y, n.Z, u0, v0});
         verts.push_back({p2.X, p2.Y, p2.Z, n.X, n.Y, n.Z, u1, v1});
         verts.push_back({p3.X, p3.Y, p3.Z, n.X, n.Y, n.Z, u2, v2});
-        // Re-upload vertex data for animated meshes
+    }
+
+    // Re-upload vertex data for animated meshes (version changed but entry exists)
+    if (it != meshCache_.end()) {
         MeshCacheEntry& entry = it->second;
         GLsizeiptr dataSize = static_cast<GLsizeiptr>(verts.size() * sizeof(GLVertex));
         glBindBuffer(GL_ARRAY_BUFFER, entry.vbo);

--- a/engine/koilo/systems/render/gl/render_backend_factory.cpp
+++ b/engine/koilo/systems/render/gl/render_backend_factory.cpp
@@ -2,6 +2,11 @@
 /**
  * @file render_backend_factory.cpp
  * @brief Factory for creating the best available render backend.
+ *
+ * Supports three paths:
+ *  1. Vulkan unified pipeline (VulkanRHIDevice + RenderPipeline)
+ *  2. Legacy Vulkan backend (VulkanRenderBackend, opt-in via r.legacy_backend)
+ *  3. OpenGL GPU backend -> Software fallback
  */
 
 #include <koilo/systems/render/gl/render_backend_factory.hpp>
@@ -10,11 +15,17 @@
 #endif
 #include <koilo/systems/render/gl/software_render_backend.hpp>
 #include <koilo/systems/render/material/implementations/kslmaterial.hpp>
+#include <koilo/systems/render/render_cvars.hpp>
 #include <koilo/ksl/ksl_symbols.hpp>
+#include <koilo/ksl/ksl_registry.hpp>
+#include <koilo/kernel/logging/log.hpp>
 #include <iostream>
+#include <fstream>
 
 #ifdef KL_HAVE_VULKAN_BACKEND
 #include <koilo/systems/render/vk/vulkan_render_backend.hpp>
+#include <koilo/systems/render/rhi/vulkan/vulkan_rhi_device.hpp>
+#include <koilo/systems/render/pipeline/render_pipeline.hpp>
 #endif
 
 namespace koilo {
@@ -26,8 +37,8 @@ std::unique_ptr<IRenderBackend> TryCreateGPURenderBackend() {
 #ifdef KL_HAVE_OPENGL_BACKEND
     auto gpu = std::make_unique<OpenGLRenderBackend>();
     if (gpu->Initialize()) {
-        std::cout << "[RenderBackendFactory] GPU render backend active ("
-                  << gpu->GetName() << ")" << std::endl;
+        KL_LOG("RenderBackendFactory", "GPU render backend active (%s)",
+               gpu->GetName());
         return gpu;
     }
 #endif
@@ -54,24 +65,190 @@ std::unique_ptr<IRenderBackend> CreateBestSoftwareBackend() {
     for (const auto& path : searchPaths) {
         int loaded = s_cpuOnlyRegistry.ScanDirectory(path, "", &symbols);
         if (loaded > 0) {
-            std::cout << "[RenderBackendFactory] Loaded " << loaded
-                      << " KSL CPU shaders from " << path << "/" << std::endl;
+            KL_LOG("RenderBackendFactory", "Loaded %d KSL CPU shaders from %s/",
+                   loaded, path.c_str());
             break;
         }
     }
     KSLMaterial::SetRegistry(&s_cpuOnlyRegistry);
 
-    std::cout << "[RenderBackendFactory] Software render backend active ("
-              << sw->GetName() << ")" << std::endl;
+    KL_LOG("RenderBackendFactory", "Software render backend active (%s)",
+           sw->GetName());
     return sw;
 }
 
 #ifdef KL_HAVE_VULKAN_BACKEND
+
+/// @brief Create a unified RenderPipeline backed by a VulkanRHIDevice.
+///
+/// Creates the RHI device, loads SPIR-V shaders from the KSL registry,
+/// wires a ShaderResolver that resolves SPIR-V bytecode by shader name,
+/// and returns the pipeline as an IGPURenderBackend.
+static std::unique_ptr<IRenderBackend> TryCreateVulkanRHIPipeline(VulkanBackend* display) {
+    // 1. Create and initialize the RHI device
+    auto rhiDevice = std::make_unique<rhi::VulkanRHIDevice>(display);
+    if (!rhiDevice->Initialize()) {
+        KL_ERR("RenderBackendFactory", "Failed to initialize Vulkan RHI device");
+        return nullptr;
+    }
+
+    // 2. Create a KSL registry and scan for SPIR-V + KSO shaders
+    auto registry = std::make_unique<ksl::KSLRegistry>();
+    ksl::KSLSymbolTable symbols;
+    symbols.RegisterAll();
+
+    std::vector<std::string> searchPaths = {
+        "build/shaders/spirv",
+        "../build/shaders/spirv",
+        "shaders/spirv",
+    };
+    for (const auto& spirvDir : searchPaths) {
+        int count = registry->ScanSPIRVDirectory(spirvDir);
+        if (count > 0) {
+            KL_LOG("RenderBackendFactory", "Loaded %d SPIR-V shaders from %s",
+                   count, spirvDir.c_str());
+            // Also load KSO CPU modules for material parameter support
+            std::string ksoDir = spirvDir;
+            auto pos = ksoDir.rfind("/spirv");
+            if (pos != std::string::npos) ksoDir = ksoDir.substr(0, pos);
+            int ksoCount = registry->ScanDirectory(ksoDir, "", &symbols);
+            if (ksoCount > 0)
+                KL_LOG("RenderBackendFactory", "Loaded %d KSO CPU modules from %s",
+                       ksoCount, ksoDir.c_str());
+            break;
+        }
+    }
+
+    if (!registry->HasSPIRV()) {
+        KL_ERR("RenderBackendFactory", "No SPIR-V shaders found for RHI pipeline");
+        return nullptr;
+    }
+
+    // Make registry available to KSLMaterial for script-based shader binding
+    KSLMaterial::SetRegistry(registry.get());
+
+    // 3. Build the shader resolver: resolves SPIR-V by shader name
+    //    Capture raw pointer - the pipeline owns the registry via OwnRegistry().
+    //
+    //    Built-in pipelines use different vertex shaders than the scene pipeline:
+    //      __blit__, __overlay__   -> blit.vert.spv + blit.frag.spv
+    //      __debug_line__          -> line.vert.spv + line.frag.spv
+    //      __pink_error__          -> scene.vert.spv + uniform_color.frag.spv
+    //      sky, everything else    -> scene.vert.spv + <name>.frag.spv
+
+    // Load additional vertex SPIR-V files that built-in pipelines need
+    auto loadSPIRV = [](const std::string& path) -> std::vector<uint32_t> {
+        std::ifstream f(path, std::ios::binary | std::ios::ate);
+        if (!f) return {};
+        auto size = f.tellg();
+        if (size <= 0 || size % 4 != 0) return {};
+        f.seekg(0);
+        std::vector<uint32_t> data(static_cast<size_t>(size) / 4);
+        f.read(reinterpret_cast<char*>(data.data()), size);
+        return data;
+    };
+
+    // Find the SPIR-V directory that was successfully scanned
+    std::string spirvDir;
+    for (const auto& dir : searchPaths) {
+        if (std::ifstream(dir + "/scene.vert.spv")) { spirvDir = dir; break; }
+    }
+
+    auto blitVertSPV = loadSPIRV(spirvDir + "/blit.vert.spv");
+    auto blitFragSPV = loadSPIRV(spirvDir + "/blit.frag.spv");
+    auto lineVertSPV = loadSPIRV(spirvDir + "/line.vert.spv");
+    auto lineFragSPV = loadSPIRV(spirvDir + "/line.frag.spv");
+
+    if (blitVertSPV.empty()) KL_WARN("RenderBackendFactory", "blit.vert.spv not found");
+    if (lineVertSPV.empty()) KL_WARN("RenderBackendFactory", "line.vert.spv not found");
+
+    ksl::KSLRegistry* regPtr = registry.get();
+    rhi::ShaderResolver resolver = [regPtr,
+                                    blitVert = std::move(blitVertSPV),
+                                    blitFrag = std::move(blitFragSPV),
+                                    lineVert = std::move(lineVertSPV),
+                                    lineFrag = std::move(lineFragSPV)](
+                                       const std::string& name) -> rhi::ShaderData {
+        rhi::ShaderData sd;
+
+        // Select vertex + fragment SPIR-V based on built-in name
+        const std::vector<uint32_t>* vertSPV = nullptr;
+        const std::vector<uint32_t>* fragSPV = nullptr;
+
+        if (name == "__blit__" || name == "__overlay__") {
+            vertSPV = &blitVert;
+            fragSPV = &blitFrag;
+        } else if (name == "__debug_line__") {
+            vertSPV = &lineVert;
+            fragSPV = &lineFrag;
+        } else if (name == "__pink_error__") {
+            // Pink error uses scene vertex shader + uniform_color fragment
+            vertSPV = &regPtr->GetVertexSPIRV();
+            fragSPV = &regPtr->GetFragmentSPIRV("uniform_color");
+        } else {
+            // Scene shader: use shared vertex + per-name fragment
+            vertSPV = &regPtr->GetVertexSPIRV();
+            fragSPV = &regPtr->GetFragmentSPIRV(name);
+        }
+
+        if (vertSPV && !vertSPV->empty()) {
+            sd.vertexCode     = vertSPV->data();
+            sd.vertexCodeSize = vertSPV->size() * sizeof(uint32_t);
+        }
+        if (fragSPV && !fragSPV->empty()) {
+            sd.fragCode     = fragSPV->data();
+            sd.fragCodeSize = fragSPV->size() * sizeof(uint32_t);
+        }
+        return sd;
+    };
+
+    // 4. Configure and initialize the unified pipeline
+    auto pipeline = std::make_unique<rhi::RenderPipeline>();
+
+    rhi::RenderPipelineConfig cfg;
+    cfg.device          = rhiDevice.get();
+    cfg.shaderRegistry  = registry.get();
+    cfg.shaderResolver  = std::move(resolver);
+    cfg.vulkanDepthRemap = true;     // Vulkan uses [0,1] depth range
+    cfg.initialWidth    = 1920;
+    cfg.initialHeight   = 1080;
+    pipeline->Configure(cfg);
+
+    // Transfer ownership of device + registry to the pipeline
+    pipeline->OwnDevice(std::move(rhiDevice));
+    pipeline->OwnRegistry(std::move(registry));
+
+    if (!pipeline->Initialize()) {
+        KL_ERR("RenderBackendFactory", "Failed to initialize RHI RenderPipeline");
+        return nullptr;
+    }
+
+    KL_LOG("RenderBackendFactory", "Vulkan render backend active (RHI Pipeline)");
+    return pipeline;
+}
+
 std::unique_ptr<IRenderBackend> TryCreateVulkanRenderBackend(VulkanBackend* display) {
     if (!display) return nullptr;
+
+    // Allow opt-in to legacy backend via CVar
+    if (cvar_r_legacy_backend.Get()) {
+        auto vk = std::make_unique<VulkanRenderBackend>(display);
+        if (vk->Initialize()) {
+            KL_LOG("RenderBackendFactory", "Vulkan render backend active (legacy)");
+            return vk;
+        }
+        return nullptr;
+    }
+
+    // Default: unified RHI pipeline
+    auto pipeline = TryCreateVulkanRHIPipeline(display);
+    if (pipeline) return pipeline;
+
+    // Fallback to legacy backend if unified pipeline fails
+    KL_WARN("RenderBackendFactory", "RHI pipeline failed, falling back to legacy Vulkan backend");
     auto vk = std::make_unique<VulkanRenderBackend>(display);
     if (vk->Initialize()) {
-        std::cout << "[RenderBackendFactory] Vulkan render backend active" << std::endl;
+        KL_LOG("RenderBackendFactory", "Vulkan render backend active (legacy fallback)");
         return vk;
     }
     return nullptr;

--- a/engine/koilo/systems/render/pipeline/material_binder.cpp
+++ b/engine/koilo/systems/render/pipeline/material_binder.cpp
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file material_binder.cpp
+ * @brief Shared material -> pipeline / UBO binder – implementation.
+ *
+ * Handles pipeline resolution via the injected PipelineResolver callback
+ * and marshals KSL material parameters into std140-layout uniform buffers.
+ *
+ * @date 03/18/2026
+ * @author Coela Can't
+ */
+
+#include "material_binder.hpp"
+#include "../rhi/rhi_device.hpp"
+#include <koilo/systems/render/material/implementations/kslmaterial.hpp>
+#include <koilo/ksl/ksl_module.hpp>
+#include <koilo/ksl/ksl_shader.hpp>
+#include <cstring>
+#include <vector>
+
+namespace koilo::rhi {
+
+// -- Lifetime -----------------------------------------------------------
+
+MaterialBinder::MaterialBinder(IRHIDevice* device)
+    : device_(device) {}
+
+MaterialBinder::~MaterialBinder() { Clear(); }
+
+// -- Setup --------------------------------------------------------------
+
+void MaterialBinder::SetPipelineResolver(PipelineResolver resolver)
+{
+    resolver_ = std::move(resolver);
+}
+
+// -- Binding ------------------------------------------------------------
+
+const MaterialBinding* MaterialBinder::Bind(const KSLMaterial* material)
+{
+    if (!material || !resolver_)
+        return nullptr;
+
+    const uintptr_t key = reinterpret_cast<uintptr_t>(material);
+
+    // Fast path – already cached and valid.
+    auto it = cache_.find(key);
+    if (it != cache_.end() && it->second.valid)
+        return &it->second;
+
+    // Resolve the module / shader name.
+    ksl::KSLModule* mod = material->GetModule();
+    if (!mod)
+        return nullptr;
+
+    const std::string& shaderName = mod->Name();
+    if (shaderName.empty())
+        return nullptr;
+
+    // Build render flags from shader metadata (if any).
+    const RenderFlags* flagsPtr = nullptr;
+    RenderFlags flags{};
+    if (mod->GetMetadata().count > 0) {
+        flags.depthStencil.depthTest  = mod->GetMetaInt("depthTest", 1) != 0;
+        flags.depthStencil.depthWrite = mod->GetMetaInt("depthWrite", 1) != 0;
+        int cm = mod->GetMetaInt("cullMode", 2); // default Back=2
+        flags.cullMode = static_cast<RHICullMode>(
+            cm >= 0 && cm <= 3 ? cm : 2);
+        flagsPtr = &flags;
+    }
+
+    // Ask the backend to compile / look-up the pipeline.
+    RHIPipeline pipeline = resolver_(shaderName, flagsPtr);
+    if (!pipeline.IsValid())
+        return nullptr;
+
+    MaterialBinding& binding = cache_[key];
+    binding.pipeline = pipeline;
+
+    // Calculate UBO size from the module's parameter declarations.
+    ksl::ParamList params = mod->GetParams();
+    size_t uboSize = CalculateUBOLayout(params);
+
+    // Create the uniform buffer if the shader has parameters.
+    if (uboSize > 0) {
+        RHIBufferDesc desc{};
+        desc.size        = uboSize;
+        desc.usage       = RHIBufferUsage::Uniform;
+        desc.hostVisible = true;
+
+        binding.uniformBuffer = device_->CreateBuffer(desc);
+        binding.uniformSize   = uboSize;
+
+        // Marshal current parameter values and upload.
+        std::vector<uint8_t> staging(uboSize, 0);
+        MarshalUBOData(material, staging.data(), uboSize);
+        device_->UpdateBuffer(binding.uniformBuffer,
+                              staging.data(), uboSize, 0);
+    }
+
+    binding.valid = true;
+    return &binding;
+}
+
+// -- Uniform update -----------------------------------------------------
+
+void MaterialBinder::UpdateUniforms(const KSLMaterial* material)
+{
+    if (!material)
+        return;
+
+    const uintptr_t key = reinterpret_cast<uintptr_t>(material);
+    auto it = cache_.find(key);
+    if (it == cache_.end() || !it->second.valid)
+        return;
+
+    MaterialBinding& binding = it->second;
+    if (binding.uniformSize == 0)
+        return;
+
+    std::vector<uint8_t> staging(binding.uniformSize, 0);
+    MarshalUBOData(material, staging.data(), binding.uniformSize);
+    device_->UpdateBuffer(binding.uniformBuffer,
+                          staging.data(), binding.uniformSize, 0);
+}
+
+// -- Invalidation -------------------------------------------------------
+
+void MaterialBinder::Invalidate(const KSLMaterial* material)
+{
+    if (!material)
+        return;
+
+    const uintptr_t key = reinterpret_cast<uintptr_t>(material);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+        if (it->second.uniformSize > 0)
+            device_->DestroyBuffer(it->second.uniformBuffer);
+        // Pipeline is NOT destroyed – it may be shared via the resolver cache.
+        cache_.erase(it);
+    }
+}
+
+void MaterialBinder::Clear()
+{
+    for (auto& [key, binding] : cache_) {
+        if (binding.uniformSize > 0)
+            device_->DestroyBuffer(binding.uniformBuffer);
+        // Pipeline is NOT destroyed – it may be shared via the resolver cache.
+    }
+    cache_.clear();
+}
+
+// -- Accessors ----------------------------------------------------------
+
+size_t MaterialBinder::Size() const { return cache_.size(); }
+
+// -- Std140 layout helpers ----------------------------------------------
+
+size_t MaterialBinder::Std140Align(size_t offset, size_t alignment)
+{
+    return (offset + alignment - 1) & ~(alignment - 1);
+}
+
+size_t MaterialBinder::Std140ParamSize(ksl::ParamType type)
+{
+    switch (type) {
+        case ksl::ParamType::Float: return 4;
+        case ksl::ParamType::Int:   return 4;
+        case ksl::ParamType::Bool:  return 4;
+        case ksl::ParamType::Vec2:  return 8;
+        case ksl::ParamType::Vec3:  return 12;
+        case ksl::ParamType::Vec4:  return 16;
+        default:                    return 4;
+    }
+}
+
+size_t MaterialBinder::Std140ParamAlignment(ksl::ParamType type)
+{
+    switch (type) {
+        case ksl::ParamType::Float: return 4;
+        case ksl::ParamType::Int:   return 4;
+        case ksl::ParamType::Bool:  return 4;
+        case ksl::ParamType::Vec2:  return 8;
+        case ksl::ParamType::Vec3:  return 16; // vec3 has 16-byte alignment in std140
+        case ksl::ParamType::Vec4:  return 16;
+        default:                    return 4;
+    }
+}
+
+size_t MaterialBinder::CalculateUBOLayout(const ksl::ParamList& params) const
+{
+    if (!params.decls || params.count <= 0)
+        return 0;
+
+    size_t offset = 0;
+    for (int i = 0; i < params.count; ++i) {
+        const ksl::ParamDecl& p = params.decls[i];
+        size_t align = Std140ParamAlignment(p.type);
+        size_t size  = Std140ParamSize(p.type);
+        offset = Std140Align(offset, align);
+
+        if (p.flags == ksl::ParamFlags::Array && p.arraySize > 0) {
+            size_t stride = Std140Align(size, align);
+            offset += static_cast<size_t>(p.arraySize) * stride;
+        } else {
+            offset += size;
+        }
+    }
+    return offset;
+}
+
+// -- UBO marshalling ----------------------------------------------------
+
+void MaterialBinder::MarshalUBOData(const KSLMaterial* material,
+                                    void* dst, size_t bufferSize) const
+{
+    ksl::KSLModule* mod = material->GetModule();
+    if (!mod)
+        return;
+
+    ksl::ParamList params = mod->GetParams();
+    void* instance = material->GetInstance();
+    if (!instance || !params.decls || params.count <= 0)
+        return;
+
+    uint8_t* out = static_cast<uint8_t*>(dst);
+    std::memset(out, 0, bufferSize);
+    size_t offset = 0;
+
+    for (int i = 0; i < params.count; ++i) {
+        const ksl::ParamDecl& p = params.decls[i];
+        size_t align = Std140ParamAlignment(p.type);
+        size_t size  = Std140ParamSize(p.type);
+        offset = Std140Align(offset, align);
+
+        const uint8_t* src =
+            static_cast<const uint8_t*>(instance) + p.offset;
+
+        if (p.flags == ksl::ParamFlags::Array && p.arraySize > 0) {
+            size_t stride = Std140Align(size, align);
+            for (int j = 0; j < p.arraySize; ++j) {
+                size_t elemOffset = Std140Align(offset + static_cast<size_t>(j) * stride, align);
+                if (elemOffset + size <= bufferSize)
+                    std::memcpy(out + elemOffset, src + static_cast<size_t>(j) * size, size);
+            }
+            offset += static_cast<size_t>(p.arraySize) * stride;
+        } else {
+            if (offset + size <= bufferSize)
+                std::memcpy(out + offset, src, size);
+            offset += size;
+        }
+    }
+}
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/material_binder.hpp
+++ b/engine/koilo/systems/render/pipeline/material_binder.hpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file material_binder.hpp
+ * @brief Shared material -> pipeline / UBO binder using the RHI abstraction layer.
+ *
+ * Resolves a KSLMaterial to a backend-agnostic RHIPipeline and creates a
+ * std140-layout uniform buffer for the material's parameters.  Both the
+ * OpenGL and Vulkan backends delegate here instead of duplicating the
+ * material -> pipeline resolution and uniform marshalling logic.
+ *
+ * The binder itself is shader-language-agnostic: it receives a
+ * PipelineResolver callback from the render pipeline that knows how to
+ * compile shaders (GLSL for OpenGL, SPIR-V for Vulkan).
+ *
+ * @date 03/18/2026
+ * @author Coela Can't
+ */
+#pragma once
+
+#include "../rhi/rhi_types.hpp"
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <cstdint>
+#include "../../../registry/reflect_macros.hpp"
+
+namespace koilo      { class KSLMaterial; }
+namespace koilo::rhi { class IRHIDevice; }
+namespace ksl        { struct ParamList; enum class ParamType : uint8_t; }
+
+namespace koilo::rhi {
+
+// -- PipelineResolver callback ------------------------------------------
+//
+// Given a shader name and optional render flags (from shader metadata),
+// returns a ready-to-use RHIPipeline.  The render pipeline provides this,
+// handling backend-specific shader compilation.
+using PipelineResolver = std::function<RHIPipeline(const std::string& shaderName,
+                                                    const RenderFlags* flags)>;
+
+// -- MaterialBinding ----------------------------------------------------
+
+struct MaterialBinding {
+    RHIPipeline pipeline;            ///< Resolved pipeline for this material's shader.
+    RHIBuffer   uniformBuffer;       ///< Material parameter UBO (std140 layout).
+    size_t      uniformSize = 0;     ///< Size of the UBO data in bytes.
+    bool        valid       = false; ///< True once the pipeline is resolved.
+};
+
+// -- MaterialBinder -----------------------------------------------------
+
+/**
+ * @class MaterialBinder
+ * @brief Backend-agnostic cache that maps KSLMaterials to RHI pipelines and
+ *        std140 uniform buffers.
+ *
+ * Typical usage:
+ *   1. Construct with the RHI device pointer.
+ *   2. Call SetPipelineResolver() once during render-pipeline setup.
+ *   3. For each KSLMaterial encountered during a frame, call Bind() to
+ *      obtain (or create) the cached binding.
+ *   4. Call UpdateUniforms() when material parameters change (e.g. per-frame).
+ */
+class MaterialBinder {
+public:
+    explicit MaterialBinder(IRHIDevice* device);
+    ~MaterialBinder();
+
+    MaterialBinder(const MaterialBinder&)            = delete;
+    MaterialBinder& operator=(const MaterialBinder&) = delete;
+
+    // -- Setup ----------------------------------------------------------
+
+    /**
+     * @brief Set the pipeline resolver callback (called once during setup).
+     * @param resolver  Callback that compiles/caches a pipeline for a shader name.
+     */
+    void SetPipelineResolver(PipelineResolver resolver);
+
+    // -- Binding --------------------------------------------------------
+
+    /**
+     * @brief  Resolve a KSLMaterial to its pipeline + UBO, creating or
+     *         reusing a cached binding.
+     * @param  material  The KSL material to bind (may be nullptr).
+     * @return Pointer to the cached binding, or nullptr if the material is
+     *         not a KSL material, has no module, or the resolver is not set.
+     */
+    const MaterialBinding* Bind(const KSLMaterial* material);
+
+    /**
+     * @brief  Re-marshal the material's current parameter values into the
+     *         cached UBO and upload to the GPU.
+     * @param  material  The KSL material whose uniforms have changed.
+     */
+    void UpdateUniforms(const KSLMaterial* material);
+
+    // -- Invalidation ---------------------------------------------------
+
+    /**
+     * @brief Remove a single material from the cache, destroying its UBO.
+     * @note  The pipeline is NOT destroyed – it may be shared via the
+     *        resolver's own cache.
+     */
+    void Invalidate(const KSLMaterial* material);
+
+    /**
+     * @brief Destroy every cached UBO and clear the cache.
+     */
+    void Clear();
+
+    /**
+     * @brief Number of material bindings currently held in the cache.
+     */
+    size_t Size() const;
+
+private:
+    IRHIDevice*                                  device_;
+    PipelineResolver                             resolver_;
+    std::unordered_map<uintptr_t, MaterialBinding> cache_;
+
+    // -- Std140 layout helpers ------------------------------------------
+
+    static size_t Std140Align(size_t offset, size_t alignment);
+    static size_t Std140ParamSize(ksl::ParamType type);
+    static size_t Std140ParamAlignment(ksl::ParamType type);
+    size_t CalculateUBOLayout(const ksl::ParamList& params) const;
+    void   MarshalUBOData(const KSLMaterial* material,
+                          void* dst, size_t bufferSize) const;
+
+    KL_BEGIN_FIELDS(MaterialBinder)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(MaterialBinder)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(MaterialBinder)
+        KL_CTOR(MaterialBinder, IRHIDevice*)
+    KL_END_DESCRIBE(MaterialBinder)
+
+};
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/mesh_cache.cpp
+++ b/engine/koilo/systems/render/pipeline/mesh_cache.cpp
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file mesh_cache.cpp
+ * @brief Shared GPU mesh cache – implementation.
+ *
+ * Builds interleaved position/normal/UV vertex arrays from engine Mesh
+ * geometry and uploads them through the RHI device interface.  Tracks
+ * mesh GPU versions to re-upload only when geometry has changed.
+ *
+ * @date 03/18/2026
+ * @author Coela Can't
+ */
+
+#include "mesh_cache.hpp"
+#include "../rhi/rhi_device.hpp"
+#include <koilo/systems/scene/mesh.hpp>
+#include <koilo/assets/model/itrianglegroup.hpp>
+#include <koilo/core/geometry/3d/triangle.hpp>
+#include <koilo/assets/model/indexgroup.hpp>
+#include <koilo/core/math/vector3d.hpp>
+#include <koilo/core/math/vector2d.hpp>
+#include <vector>
+
+namespace koilo::rhi {
+
+// -- Lifetime -----------------------------------------------------------
+
+MeshCache::MeshCache(IRHIDevice* device)
+    : device_(device) {}
+
+MeshCache::~MeshCache() { Clear(); }
+
+// -- Query / upload -----------------------------------------------------
+
+const CachedMesh* MeshCache::GetOrUpload(Mesh* mesh)
+{
+    if (!mesh)
+        return nullptr;
+
+    ITriangleGroup* tg = mesh->GetTriangleGroup();
+    if (!tg)
+        return nullptr;
+
+    const uint32_t triCount = tg->GetTriangleCount();
+    if (triCount == 0)
+        return nullptr;
+
+    const uintptr_t key     = reinterpret_cast<uintptr_t>(mesh);
+    const uint32_t  version = mesh->GetGPUVersion();
+
+    // Fast path – already cached and up-to-date.
+    auto it = cache_.find(key);
+    if (it != cache_.end() && it->second.version == version)
+        return &it->second;
+
+    // Build interleaved vertex array from mesh geometry.
+    Triangle3D* triangles = tg->GetTriangles();
+    const bool       hasUV     = mesh->HasUV();
+    const Vector2D*  uvVerts   = hasUV ? mesh->GetUVVertices()  : nullptr;
+    const IndexGroup* uvIndices = hasUV ? mesh->GetUVIndexGroup() : nullptr;
+
+    std::vector<RHIVertex> verts;
+    verts.reserve(triCount * 3);
+
+    for (uint32_t i = 0; i < triCount; ++i) {
+        const Triangle3D& tri = triangles[i];
+        const Vector3D& p1 = *tri.p1;
+        const Vector3D& p2 = *tri.p2;
+        const Vector3D& p3 = *tri.p3;
+
+        // Face normal from cross product.
+        Vector3D n   = (p2 - p1).CrossProduct(p3 - p1);
+        float    len = n.Magnitude();
+        if (len > 1e-8f)
+            n = n * (1.0f / len);
+
+        float u0 = 0, v0 = 0, u1 = 0, v1 = 0, u2 = 0, v2 = 0;
+        if (hasUV && uvIndices && uvVerts) {
+            const IndexGroup& uvIdx = uvIndices[i];
+            u0 = uvVerts[uvIdx.A].X;  v0 = uvVerts[uvIdx.A].Y;
+            u1 = uvVerts[uvIdx.B].X;  v1 = uvVerts[uvIdx.B].Y;
+            u2 = uvVerts[uvIdx.C].X;  v2 = uvVerts[uvIdx.C].Y;
+        }
+
+        verts.push_back({p1.X, p1.Y, p1.Z, n.X, n.Y, n.Z, u0, v0});
+        verts.push_back({p2.X, p2.Y, p2.Z, n.X, n.Y, n.Z, u1, v1});
+        verts.push_back({p3.X, p3.Y, p3.Z, n.X, n.Y, n.Z, u2, v2});
+    }
+
+    // Destroy stale buffer if re-uploading.
+    if (it != cache_.end())
+        device_->DestroyBuffer(it->second.vertexBuffer);
+
+    // Create RHI buffer and upload vertex data.
+    RHIBufferDesc desc{};
+    desc.size        = verts.size() * sizeof(RHIVertex);
+    desc.usage       = RHIBufferUsage::Vertex;
+    desc.hostVisible = true;
+
+    RHIBuffer buf = device_->CreateBuffer(desc);
+    device_->UpdateBuffer(buf, verts.data(), desc.size, 0);
+
+    CachedMesh entry{buf, static_cast<int>(verts.size()), version};
+    cache_[key] = entry;
+    return &cache_[key];
+}
+
+// -- Invalidation -------------------------------------------------------
+
+void MeshCache::Invalidate(Mesh* mesh)
+{
+    if (!mesh)
+        return;
+
+    const uintptr_t key = reinterpret_cast<uintptr_t>(mesh);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+        device_->DestroyBuffer(it->second.vertexBuffer);
+        cache_.erase(it);
+    }
+}
+
+void MeshCache::Clear()
+{
+    for (auto& [key, entry] : cache_)
+        device_->DestroyBuffer(entry.vertexBuffer);
+    cache_.clear();
+}
+
+// -- Accessors ----------------------------------------------------------
+
+size_t MeshCache::Size() const { return cache_.size(); }
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/mesh_cache.hpp
+++ b/engine/koilo/systems/render/pipeline/mesh_cache.hpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file mesh_cache.hpp
+ * @brief Shared GPU mesh cache using the RHI abstraction layer.
+ *
+ * Converts engine Mesh geometry to interleaved vertex buffers on first use
+ * and caches them so that both the OpenGL and Vulkan backends avoid
+ * duplicating the Mesh -> GPU buffer upload logic.  Re-uploads automatically
+ * when the mesh GPU version changes.
+ *
+ * @date 03/18/2026
+ * @author Coela Can't
+ */
+#pragma once
+
+#include "../rhi/rhi_types.hpp"
+#include <unordered_map>
+#include <cstdint>
+#include "../../../registry/reflect_macros.hpp"
+
+namespace koilo      { class Mesh; }
+namespace koilo::rhi { class IRHIDevice; }
+
+namespace koilo::rhi {
+
+// -- Shared vertex format (32 bytes) ------------------------------------
+
+struct RHIVertex {
+    float px, py, pz;   // position
+    float nx, ny, nz;   // normal (face normal from cross product)
+    float u, v;          // texcoord
+};
+
+// -- Cached mesh entry --------------------------------------------------
+
+struct CachedMesh {
+    RHIBuffer vertexBuffer;
+    int       vertexCount = 0;
+    uint32_t  version     = 0;
+};
+
+// -- MeshCache ----------------------------------------------------------
+
+class MeshCache {
+public:
+    explicit MeshCache(IRHIDevice* device);
+    ~MeshCache();
+
+    MeshCache(const MeshCache&)            = delete;
+    MeshCache& operator=(const MeshCache&) = delete;
+
+    /**
+     * @brief  Return the cached mesh, uploading or re-uploading if the
+     *         GPU version changed.
+     * @param  mesh  Source engine mesh (may be nullptr).
+     * @return Pointer to cached entry, or nullptr when the mesh is null
+     *         or contains no triangles.
+     */
+    const CachedMesh* GetOrUpload(Mesh* mesh);
+
+    /**
+     * @brief Remove a single mesh from the cache and destroy its GPU buffer.
+     * @param mesh  The engine mesh to invalidate.
+     */
+    void Invalidate(Mesh* mesh);
+
+    /**
+     * @brief Destroy every cached GPU buffer and clear the cache.
+     */
+    void Clear();
+
+    /**
+     * @brief Number of meshes currently held in the cache.
+     */
+    size_t Size() const;
+
+private:
+    IRHIDevice*                              device_;
+    std::unordered_map<uintptr_t, CachedMesh> cache_;
+
+    KL_BEGIN_FIELDS(MeshCache)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(MeshCache)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(MeshCache)
+        KL_CTOR(MeshCache, IRHIDevice*)
+    KL_END_DESCRIBE(MeshCache)
+
+};
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/render_pipeline.cpp
+++ b/engine/koilo/systems/render/pipeline/render_pipeline.cpp
@@ -1,0 +1,1127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file render_pipeline.cpp
+ * @brief Unified GPU render pipeline implementation.
+ *
+ * Single implementation of scene traversal, sky rendering, debug lines,
+ * overlay compositing, and blit-to-screen using the RHI abstraction.
+ * Replaces duplicated logic that previously lived in both the OpenGL
+ * and Vulkan render backends).
+ *
+ * @date 03/19/2026
+ * @author Coela Can't
+ */
+
+#include "render_pipeline.hpp"
+
+#include <koilo/systems/render/rhi/rhi_device.hpp>
+#include <koilo/systems/scene/scene.hpp>
+#include <koilo/systems/scene/mesh.hpp>
+#include <koilo/systems/scene/camera/camerabase.hpp>
+#include <koilo/systems/scene/camera/cameralayout.hpp>
+#include <koilo/systems/render/sky/sky.hpp>
+#include <koilo/systems/render/material/imaterial.hpp>
+#include <koilo/systems/render/material/implementations/kslmaterial.hpp>
+#include <koilo/assets/image/texture.hpp>
+#include <koilo/assets/model/itrianglegroup.hpp>
+#include <koilo/core/math/matrix4x4.hpp>
+#include <koilo/core/math/transform.hpp>
+#include <koilo/core/math/quaternion.hpp>
+#include <koilo/core/math/vector3d.hpp>
+#include <koilo/core/math/vector2d.hpp>
+#include <koilo/core/color/color888.hpp>
+#include <koilo/debug/debugdraw.hpp>
+#include <koilo/systems/render/canvas2d.hpp>
+#include <koilo/kernel/logging/log.hpp>
+#include <koilo/ksl/ksl_registry.hpp>
+#include <koilo/ksl/ksl_module.hpp>
+#include <koilo/systems/profiling/performanceprofiler.hpp>
+
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+#include <vector>
+
+namespace koilo::rhi {
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+static constexpr size_t kMaxDebugLineVerts  = 65536;
+static constexpr float  kPi                 = 3.14159265358979323846f;
+
+// ── Fullscreen quad geometry (NDC) ─────────────────────────────────────
+
+static const FullscreenVertex kQuadVerts[6] = {
+    {-1.0f, -1.0f, 0.0f, 0.0f},
+    { 1.0f, -1.0f, 1.0f, 0.0f},
+    { 1.0f,  1.0f, 1.0f, 1.0f},
+    {-1.0f, -1.0f, 0.0f, 0.0f},
+    { 1.0f,  1.0f, 1.0f, 1.0f},
+    {-1.0f,  1.0f, 0.0f, 1.0f},
+};
+
+// ── Constructor / Destructor ───────────────────────────────────────────
+
+RenderPipeline::RenderPipeline() = default;
+RenderPipeline::~RenderPipeline() {
+    if (initialized_) Shutdown();
+}
+
+// ── Configure ──────────────────────────────────────────────────────────
+
+void RenderPipeline::Configure(const RenderPipelineConfig& config) {
+    config_ = config;
+}
+
+void RenderPipeline::OwnDevice(std::unique_ptr<IRHIDevice> device) {
+    ownedDevice_ = std::move(device);
+}
+
+void RenderPipeline::OwnRegistry(std::unique_ptr<ksl::KSLRegistry> registry) {
+    ownedRegistry_ = std::move(registry);
+}
+
+// ── IRenderBackend: Initialize ─────────────────────────────────────────
+
+bool RenderPipeline::Initialize() {
+    if (initialized_) return true;
+    if (!config_.device) {
+        KL_ERR("RenderPipeline", "No RHI device configured");
+        return false;
+    }
+
+    auto* device = config_.device;
+
+    // -- Shared caches -----------------------------------------------
+    meshCache_     = std::make_unique<MeshCache>(device);
+    textureCache_  = std::make_unique<TextureCache>(device);
+    materialBinder_ = std::make_unique<MaterialBinder>(device);
+    materialBinder_->SetPipelineResolver(
+        [this](const std::string& name, const RenderFlags* flags) {
+            return GetOrCreateScenePipeline(name, flags);
+        }
+    );
+
+    // -- Fullscreen quad VBO -----------------------------------------
+    {
+        RHIBufferDesc desc{};
+        desc.size        = sizeof(kQuadVerts);
+        desc.usage       = RHIBufferUsage::Vertex;
+        desc.hostVisible = true;
+        desc.debugName   = "Pipeline.QuadVBO";
+        fullscreenQuadVBO_ = device->CreateBuffer(desc);
+        if (!fullscreenQuadVBO_.IsValid()) {
+            KL_ERR("RenderPipeline", "Failed to create fullscreen quad VBO");
+            return false;
+        }
+        device->UpdateBuffer(fullscreenQuadVBO_, kQuadVerts, sizeof(kQuadVerts));
+    }
+
+    // -- Scene-format quad VBO (RHIVertex for sky/effects through scene pipeline)
+    {
+        static const RHIVertex kSceneQuad[6] = {
+            {-1, -1, 0.5f,  0, 0, 1,  0, 0},
+            { 1, -1, 0.5f,  0, 0, 1,  1, 0},
+            { 1,  1, 0.5f,  0, 0, 1,  1, 1},
+            {-1, -1, 0.5f,  0, 0, 1,  0, 0},
+            { 1,  1, 0.5f,  0, 0, 1,  1, 1},
+            {-1,  1, 0.5f,  0, 0, 1,  0, 1},
+        };
+        RHIBufferDesc desc{};
+        desc.size        = sizeof(kSceneQuad);
+        desc.usage       = RHIBufferUsage::Vertex;
+        desc.hostVisible = true;
+        desc.debugName   = "Pipeline.SceneQuadVBO";
+        sceneQuadVBO_ = device->CreateBuffer(desc);
+        if (sceneQuadVBO_.IsValid())
+            device->UpdateBuffer(sceneQuadVBO_, kSceneQuad, sizeof(kSceneQuad));
+    }
+
+    // -- Debug line VBO (dynamic, allocated on first use) ------------
+    {
+        RHIBufferDesc desc{};
+        desc.size        = kMaxDebugLineVerts * sizeof(DebugLineVertex);
+        desc.usage       = RHIBufferUsage::Vertex;
+        desc.hostVisible = true;
+        desc.debugName   = "Pipeline.DebugLineVBO";
+        debugLineVBO_ = device->CreateBuffer(desc);
+    }
+
+    // -- Uniform buffers ---------------------------------------------
+    {
+        RHIBufferDesc desc{};
+        desc.usage       = RHIBufferUsage::Uniform;
+        desc.hostVisible = true;
+
+        desc.size      = sizeof(TransformUBO);
+        desc.debugName = "Pipeline.TransformUBO";
+        transformUBO_  = device->CreateBuffer(desc);
+
+        desc.size      = sizeof(SceneUBO);
+        desc.debugName = "Pipeline.SceneUBO";
+        sceneUBO_      = device->CreateBuffer(desc);
+
+        desc.size      = sizeof(GPULight) * kMaxGPULights;
+        desc.debugName = "Pipeline.LightSSBO";
+        desc.usage     = RHIBufferUsage::Storage;
+        lightSSBO_     = device->CreateBuffer(desc);
+
+        // Dummy audio SSBO (binding 3) — required by scene set layout
+        desc.size      = 16; // minimum
+        desc.debugName = "Pipeline.AudioSSBO";
+        desc.usage     = RHIBufferUsage::Storage;
+        audioSSBO_     = device->CreateBuffer(desc);
+
+        // Overlay UBO: single float (alpha)
+        desc.size      = 16; // std140 minimum
+        desc.usage     = RHIBufferUsage::Uniform;
+        desc.debugName = "Pipeline.OverlayUBO";
+        overlayUBO_    = device->CreateBuffer(desc);
+    }
+
+    // -- Off-screen render target ------------------------------------
+    EnsureOffscreenTarget(config_.initialWidth, config_.initialHeight);
+
+    // -- Built-in pipelines ------------------------------------------
+    CreateBuiltinPipelines();
+
+    initialized_ = true;
+    KL_LOG("RenderPipeline", "Initialized successfully (%s)",
+           config_.device->GetName());
+    return true;
+}
+
+// ── IRenderBackend: Shutdown ───────────────────────────────────────────
+
+void RenderPipeline::Shutdown() {
+    if (!initialized_) return;
+    auto* device = config_.device;
+    if (!device) return;
+
+    KL_LOG("RenderPipeline", "Shutdown: clearing caches...");
+    // Destroy shared caches (they destroy their own RHI resources)
+    materialBinder_.reset();
+    textureCache_.reset();
+    meshCache_.reset();
+
+    KL_LOG("RenderPipeline", "Shutdown: destroying pipelines...");
+    // Destroy all pipelines (scene + built-in)
+    DestroyAllPipelines();
+
+    KL_LOG("RenderPipeline", "Shutdown: destroying shaders...");
+    // Destroy built-in shaders
+    auto destroyShader = [&](RHIShader& s) {
+        if (s.IsValid()) { device->DestroyShader(s); s = {}; }
+    };
+    destroyShader(blitVertShader_);
+    destroyShader(blitFragShader_);
+    destroyShader(overlayFragShader_);
+    destroyShader(debugLineVertShader_);
+    destroyShader(debugLineFragShader_);
+    destroyShader(pinkVertShader_);
+    destroyShader(pinkFragShader_);
+
+    KL_LOG("RenderPipeline", "Shutdown: destroying buffers...");
+    // Destroy buffers
+    auto destroyBuffer = [&](RHIBuffer& b) {
+        if (b.IsValid()) { device->DestroyBuffer(b); b = {}; }
+    };
+    destroyBuffer(fullscreenQuadVBO_);
+    destroyBuffer(sceneQuadVBO_);
+    destroyBuffer(debugLineVBO_);
+    destroyBuffer(transformUBO_);
+    destroyBuffer(sceneUBO_);
+    destroyBuffer(lightSSBO_);
+    destroyBuffer(audioSSBO_);
+    destroyBuffer(overlayUBO_);
+
+    KL_LOG("RenderPipeline", "Shutdown: destroying offscreen target...");
+    // Destroy off-screen target
+    DestroyOffscreenTarget();
+
+    KL_LOG("RenderPipeline", "Shutdown: shutting down device...");
+    // Shutdown owned device (after all GPU resources are released)
+    if (ownedDevice_) {
+        ownedDevice_->Shutdown();
+        KL_LOG("RenderPipeline", "Shutdown: releasing device...");
+        ownedDevice_.reset();
+    }
+
+    KL_LOG("RenderPipeline", "Shutdown: releasing registry...");
+    // Release owned registry
+    ownedRegistry_.reset();
+
+    initialized_ = false;
+    KL_LOG("RenderPipeline", "Shutdown complete");
+}
+
+bool RenderPipeline::IsInitialized() const { return initialized_; }
+const char* RenderPipeline::GetName() const { return "RHI RenderPipeline"; }
+
+// ── IGPURenderBackend: PrepareFrame / FinishFrame ──────────────────────
+
+void RenderPipeline::PrepareFrame() {
+    if (!initialized_) return;
+    config_.device->BeginFrame();
+}
+
+void RenderPipeline::FinishFrame() {
+    if (!initialized_) return;
+    config_.device->EndFrame();
+    config_.device->Present();
+}
+
+// ── IRenderBackend: Render (single-call convenience) ───────────────────
+
+void RenderPipeline::Render(Scene* scene, CameraBase* camera) {
+    RenderDirect(scene, camera);
+}
+
+void RenderPipeline::ReadPixels(Color888* /*buffer*/, int /*width*/, int /*height*/) {
+    // Readback not yet implemented via RHI — requires staging buffer support.
+}
+
+// ── IGPURenderBackend: RenderDirect ────────────────────────────────────
+
+void RenderPipeline::RenderDirect(Scene* scene, CameraBase* camera) {
+    if (!initialized_ || !scene || !camera || camera->Is2D())
+        return;
+
+    KL_PERF_SCOPE("RenderPipeline.RenderDirect");
+
+    auto* device = config_.device;
+
+    // -- Viewport from camera ----------------------------------------
+    Vector2D minC = camera->GetCameraMinCoordinate();
+    Vector2D maxC = camera->GetCameraMaxCoordinate();
+    uint32_t vpW  = static_cast<uint32_t>(maxC.X - minC.X + 1);
+    uint32_t vpH  = static_cast<uint32_t>(maxC.Y - minC.Y + 1);
+
+    if (vpW == 0 || vpH == 0) return;
+
+    // -- Ensure off-screen render target matches ---------------------
+    EnsureOffscreenTarget(vpW, vpH);
+
+    // -- Begin off-screen render pass --------------------------------
+    RHIClearValue clear{};
+    clear.color[0] = 0.0f; clear.color[1] = 0.0f;
+    clear.color[2] = 0.0f; clear.color[3] = 1.0f;
+    clear.depth    = 1.0f;
+    clear.stencil  = 0;
+
+    device->BeginRenderPass(offscreenPass_, offscreenFB_, clear);
+
+    // -- Viewport & scissor ------------------------------------------
+    RHIViewport vp{};
+    if (config_.vulkanDepthRemap) {
+        vp.x      = 0.0f;
+        vp.y      = static_cast<float>(vpH);
+        vp.width  = static_cast<float>(vpW);
+        vp.height = -static_cast<float>(vpH);
+    } else {
+        vp.x      = 0.0f;
+        vp.y      = 0.0f;
+        vp.width  = static_cast<float>(vpW);
+        vp.height = static_cast<float>(vpH);
+    }
+    vp.minDepth = 0.0f;
+    vp.maxDepth = 1.0f;
+    device->SetViewport(vp);
+
+    RHIScissor sc{};
+    sc.x      = 0;
+    sc.y      = 0;
+    sc.width  = vpW;
+    sc.height = vpH;
+    device->SetScissor(sc);
+
+    // -- Build view/projection matrices ------------------------------
+    float viewData[16], projData[16], cameraPosData[4];
+    BuildViewProjection(camera, viewData, projData, cameraPosData);
+
+    // Compute inverseViewProj for shaders that reconstruct view direction
+    Matrix4x4 viewMat, projMat;
+    std::memcpy(&viewMat.M[0][0], viewData, 64);
+    std::memcpy(&projMat.M[0][0], projData, 64);
+    Matrix4x4 vpMat = projMat * viewMat;
+    Matrix4x4 invVP = vpMat.Inverse();
+    float invVPData[16];
+    {
+        Matrix4x4 invVPT = invVP.Transpose();
+        std::memcpy(invVPData, &invVPT.M[0][0], 64);
+    }
+
+    // -- Upload transform UBO ----------------------------------------
+    {
+        TransformUBO ubo{};
+        for (int i = 0; i < 4; ++i) ubo.model[i * 4 + i] = 1.0f;
+        std::memcpy(ubo.view, viewData, sizeof(ubo.view));
+        std::memcpy(ubo.projection, projData, sizeof(ubo.projection));
+        std::memcpy(ubo.cameraPos, cameraPosData, sizeof(ubo.cameraPos));
+        std::memcpy(ubo.inverseViewProj, invVPData, sizeof(ubo.inverseViewProj));
+        device->UpdateBuffer(transformUBO_, &ubo, sizeof(ubo));
+    }
+
+    // Bind transform UBO (set 0, binding 0)
+    device->BindUniformBuffer(transformUBO_, 0, 0);
+
+    // -- Upload lights (must precede any Draw so all set 0 bindings
+    //    are populated before the first descriptor set flush) --------
+    UploadLights(scene);
+
+    // -- Render sky (through standard material path) -----------------
+    {
+        Sky& sky = Sky::GetInstance();
+        if (sky.IsEnabled()) {
+            KSLMaterial* kmat = sky.GetMaterial();
+            if (kmat && kmat->IsBound() && kmat->GetModule()) {
+                // MaterialBinder reads metadata (depthTest=0, depthWrite=0,
+                // cullMode=0) and creates the appropriate pipeline variant
+                const MaterialBinding* binding = materialBinder_->Bind(kmat);
+                if (binding && binding->valid) {
+                    materialBinder_->UpdateUniforms(kmat);
+
+                    // Identity transform for sky (screen-space quad)
+                    TransformUBO skyUbo{};
+                    for (int i = 0; i < 4; ++i) {
+                        skyUbo.model[i * 4 + i]      = 1.0f;
+                        skyUbo.view[i * 4 + i]       = 1.0f;
+                        skyUbo.projection[i * 4 + i] = 1.0f;
+                    }
+                    std::memcpy(skyUbo.inverseViewProj, invVPData,
+                                sizeof(skyUbo.inverseViewProj));
+                    device->UpdateBuffer(transformUBO_, &skyUbo, sizeof(skyUbo));
+                    device->BindUniformBuffer(transformUBO_, 0, 0);
+
+                    device->BindPipeline(binding->pipeline);
+                    device->BindUniformBuffer(binding->uniformBuffer, 1, 0,
+                                              0, binding->uniformSize);
+
+                    // Bind texture if available (panoramic / cubemap sky)
+                    if (kmat->TextureCount() > 0) {
+                        Texture* tex = kmat->GetTexture(0);
+                        if (tex) {
+                            RHITexture gpuTex = textureCache_->GetOrUpload(tex);
+                            if (gpuTex.IsValid())
+                                device->BindTexture(gpuTex, 2, 0);
+                        }
+                    }
+
+                    // Draw sky quad (scene-format VBO through material pipeline)
+                    device->BindVertexBuffer(sceneQuadVBO_);
+                    device->Draw(6);
+
+                    // Restore camera transform for subsequent draws
+                    TransformUBO camUbo{};
+                    for (int i = 0; i < 4; ++i) camUbo.model[i * 4 + i] = 1.0f;
+                    std::memcpy(camUbo.view, viewData, sizeof(camUbo.view));
+                    std::memcpy(camUbo.projection, projData, sizeof(camUbo.projection));
+                    std::memcpy(camUbo.cameraPos, cameraPosData, sizeof(camUbo.cameraPos));
+                    std::memcpy(camUbo.inverseViewProj, invVPData,
+                                sizeof(camUbo.inverseViewProj));
+                    device->UpdateBuffer(transformUBO_, &camUbo, sizeof(camUbo));
+                    device->BindUniformBuffer(transformUBO_, 0, 0);
+                }
+            }
+        }
+    }
+
+    // -- Render scene meshes -----------------------------------------
+    RenderMeshes(scene, viewData, projData, cameraPosData);
+
+    // -- Render debug lines ------------------------------------------
+    RenderDebugLines(viewData, projData);
+
+    // -- End off-screen render pass ----------------------------------
+    device->EndRenderPass();
+}
+
+// ── IGPURenderBackend: BlitToScreen ────────────────────────────────────
+
+void RenderPipeline::BlitToScreen(int screenW, int screenH) {
+    if (!initialized_ || !offscreenColor_.IsValid()) return;
+    if (!blitPipeline_.IsValid() || !fullscreenQuadVBO_.IsValid()) return;
+
+    auto* device = config_.device;
+
+    // Begin the swapchain render pass (device manages FB internally)
+    RHIClearValue clear{};
+    clear.color[0] = 0.0f; clear.color[1] = 0.0f;
+    clear.color[2] = 0.0f; clear.color[3] = 1.0f;
+    device->BeginSwapchainRenderPass(clear);
+
+    // Set swapchain viewport/scissor
+    RHIViewport vp{};
+    vp.width    = static_cast<float>(screenW);
+    vp.height   = static_cast<float>(screenH);
+    vp.minDepth = 0.0f;
+    vp.maxDepth = 1.0f;
+    device->SetViewport(vp);
+
+    RHIScissor sc{};
+    sc.width  = static_cast<uint32_t>(screenW);
+    sc.height = static_cast<uint32_t>(screenH);
+    device->SetScissor(sc);
+
+    DrawFullscreenQuad(blitPipeline_, offscreenColor_);
+
+    // NOTE: swapchain render pass is left open for overlay/UI rendering.
+    // It is ended by VulkanBackend::SwapOnly() (or the OpenGL equivalent).
+}
+
+// ── IGPURenderBackend: CompositeCanvasOverlays ─────────────────────────
+
+void RenderPipeline::CompositeCanvasOverlays(int screenW, int screenH) {
+    auto& canvases = Canvas2D::ActiveList();
+    if (canvases.empty() || !initialized_) return;
+    if (!overlayPipeline_.IsValid() || !fullscreenQuadVBO_.IsValid()) return;
+
+    auto* device = config_.device;
+
+    for (auto* canvas : canvases) {
+        if (!canvas) continue;
+
+        int cw = canvas->GetWidth();
+        int ch = canvas->GetHeight();
+        if (cw <= 0 || ch <= 0) continue;
+
+        const Color888* pixels = canvas->GetPixels();
+        const uint8_t*  alpha  = canvas->GetAlpha();
+        if (!pixels || !alpha) continue;
+
+        // Convert RGB + separate alpha -> RGBA for GPU upload
+        size_t pixelCount = static_cast<size_t>(cw) * ch;
+        std::vector<uint8_t> rgba(pixelCount * 4);
+        for (size_t i = 0; i < pixelCount; ++i) {
+            rgba[i * 4 + 0] = pixels[i].r;
+            rgba[i * 4 + 1] = pixels[i].g;
+            rgba[i * 4 + 2] = pixels[i].b;
+            rgba[i * 4 + 3] = alpha[i];
+        }
+
+        // Create or reuse a temporary texture for this canvas
+        RHITextureDesc texDesc{};
+        texDesc.width  = static_cast<uint32_t>(cw);
+        texDesc.height = static_cast<uint32_t>(ch);
+        texDesc.format = RHIFormat::RGBA8_Unorm;
+        texDesc.usage  = RHITextureUsage::Sampled | RHITextureUsage::TransferDst;
+        texDesc.filter = RHISamplerFilter::Nearest;
+        texDesc.debugName = "Pipeline.CanvasOverlay";
+
+        RHITexture canvasTexture = device->CreateTexture(texDesc);
+        if (!canvasTexture.IsValid()) continue;
+
+        device->UpdateTexture(canvasTexture, rgba.data(), rgba.size(),
+                              texDesc.width, texDesc.height);
+
+        DrawFullscreenQuad(overlayPipeline_, canvasTexture, 1.0f);
+
+        // Destroy the temporary texture (per-frame upload)
+        device->DestroyTexture(canvasTexture);
+    }
+}
+
+// ── Off-screen render target management ────────────────────────────────
+
+void RenderPipeline::EnsureOffscreenTarget(uint32_t width, uint32_t height) {
+    if (width == offscreenWidth_ && height == offscreenHeight_
+        && offscreenFB_.IsValid()) {
+        return;
+    }
+
+    auto* device = config_.device;
+    DestroyOffscreenTarget();
+
+    // Color texture
+    {
+        RHITextureDesc desc{};
+        desc.width   = width;
+        desc.height  = height;
+        desc.format  = RHIFormat::RGBA8_Unorm;
+        desc.usage   = RHITextureUsage::RenderTarget | RHITextureUsage::Sampled;
+        desc.debugName = "Pipeline.OffscreenColor";
+        offscreenColor_ = device->CreateTexture(desc);
+    }
+
+    // Depth texture
+    {
+        RHITextureDesc desc{};
+        desc.width   = width;
+        desc.height  = height;
+        desc.format  = RHIFormat::D24_Unorm_S8_Uint;
+        desc.usage   = RHITextureUsage::DepthStencil;
+        desc.debugName = "Pipeline.OffscreenDepth";
+        offscreenDepth_ = device->CreateTexture(desc);
+    }
+
+    // Render pass
+    {
+        RHIRenderPassDesc desc{};
+        desc.colorAttachmentCount = 1;
+        desc.colorAttachments[0].format  = RHIFormat::RGBA8_Unorm;
+        desc.colorAttachments[0].loadOp  = RHILoadOp::Clear;
+        desc.colorAttachments[0].storeOp = RHIStoreOp::Store;
+        desc.colorAttachments[0].sampleAfterPass = true; // blit shader samples this
+        desc.hasDepth      = true;
+        desc.depthFormat   = RHIFormat::D24_Unorm_S8_Uint;
+        desc.depthLoadOp   = RHILoadOp::Clear;
+        desc.depthStoreOp  = RHIStoreOp::DontCare;
+        offscreenPass_ = device->CreateRenderPass(desc);
+    }
+
+    // Framebuffer
+    offscreenFB_ = device->CreateFramebuffer(
+        offscreenPass_, &offscreenColor_, 1, offscreenDepth_, width, height);
+
+    offscreenWidth_  = width;
+    offscreenHeight_ = height;
+}
+
+void RenderPipeline::DestroyOffscreenTarget() {
+    auto* device = config_.device;
+    if (!device) return;
+
+    if (offscreenFB_.IsValid())    { device->DestroyFramebuffer(offscreenFB_);  offscreenFB_ = {}; }
+    if (offscreenPass_.IsValid())  { device->DestroyRenderPass(offscreenPass_); offscreenPass_ = {}; }
+    if (offscreenDepth_.IsValid()) { device->DestroyTexture(offscreenDepth_);   offscreenDepth_ = {}; }
+    if (offscreenColor_.IsValid()) { device->DestroyTexture(offscreenColor_);   offscreenColor_ = {}; }
+
+    offscreenWidth_  = 0;
+    offscreenHeight_ = 0;
+}
+
+// ── Pipeline creation / caching ────────────────────────────────────────
+
+RHIPipeline RenderPipeline::GetOrCreateScenePipeline(const std::string& shaderName,
+                                                      const RenderFlags* flags) {
+    // Build a cache key that includes render flag overrides
+    std::string cacheKey = shaderName;
+    if (flags) {
+        cacheKey += "|d";
+        cacheKey += (flags->depthStencil.depthTest  ? '1' : '0');
+        cacheKey += (flags->depthStencil.depthWrite ? '1' : '0');
+        cacheKey += '|';
+        cacheKey += static_cast<char>('0' + static_cast<int>(flags->cullMode));
+    }
+
+    // Check cache
+    auto it = scenePipelineCache_.find(cacheKey);
+    if (it != scenePipelineCache_.end()) return it->second;
+
+    // Resolve shader bytecode via factory-provided callback
+    if (!config_.shaderResolver) {
+        KL_WARN("RenderPipeline", "No shader resolver configured");
+        return pinkErrorPipeline_;
+    }
+
+    ShaderData sd = config_.shaderResolver(shaderName);
+    if (!sd.vertexCode || !sd.fragCode || sd.vertexCodeSize == 0 || sd.fragCodeSize == 0) {
+        KL_WARN("RenderPipeline", "Shader '%s' not resolved — using pink fallback",
+                shaderName.c_str());
+        return pinkErrorPipeline_;
+    }
+
+    auto* device = config_.device;
+
+    RHIShader vertShader = device->CreateShader(
+        RHIShaderStage::Vertex, sd.vertexCode, sd.vertexCodeSize);
+    RHIShader fragShader = device->CreateShader(
+        RHIShaderStage::Fragment, sd.fragCode, sd.fragCodeSize);
+
+    if (!vertShader.IsValid() || !fragShader.IsValid()) {
+        KL_WARN("RenderPipeline", "Failed to compile shader '%s'", shaderName.c_str());
+        if (vertShader.IsValid()) device->DestroyShader(vertShader);
+        if (fragShader.IsValid()) device->DestroyShader(fragShader);
+        return pinkErrorPipeline_;
+    }
+
+    // Build pipeline descriptor for scene rendering
+    RHIPipelineDesc desc{};
+    desc.vertexShader   = vertShader;
+    desc.fragmentShader = fragShader;
+    desc.renderPass     = offscreenPass_;
+
+    // RHIVertex layout: pos3 + normal3 + uv2 (32 bytes)
+    desc.vertexAttrCount = 3;
+    desc.vertexStride    = sizeof(RHIVertex);
+    desc.vertexAttrs[0]  = {0, RHIFormat::RGB32F, 0};                            // position: 3 floats (12 bytes)
+    desc.vertexAttrs[1]  = {1, RHIFormat::RGB32F, 12};                           // normal: 3 floats (12 bytes)
+    desc.vertexAttrs[2]  = {2, RHIFormat::RG32F,  24};                           // uv: 2 floats (8 bytes)
+
+    desc.topology    = RHITopology::TriangleList;
+    desc.rasterizer  = {RHICullMode::Back, RHIFrontFace::CounterClockwise, RHIPolygonMode::Fill, false};
+    desc.depthStencil = {true, true, RHICompareOp::Less, false};
+
+    // Apply metadata-driven render flags if provided
+    if (flags) {
+        desc.depthStencil.depthTest  = flags->depthStencil.depthTest;
+        desc.depthStencil.depthWrite = flags->depthStencil.depthWrite;
+        desc.rasterizer.cullMode     = flags->cullMode;
+    }
+
+    desc.blend       = {};  // No blending for opaque scene geometry
+    desc.debugName   = shaderName.c_str();
+
+    RHIPipeline pipeline = device->CreatePipeline(desc);
+
+    // Cache even if invalid (avoid repeated creation attempts)
+    scenePipelineCache_[cacheKey] = pipeline;
+
+    // Note: shader modules can be destroyed after pipeline creation
+    // if the backend copies them. Keep them alive for safety.
+    // They will be destroyed in DestroyAllPipelines.
+
+    if (!pipeline.IsValid()) {
+        KL_WARN("RenderPipeline", "Pipeline creation failed for '%s'",
+                shaderName.c_str());
+        return pinkErrorPipeline_;
+    }
+
+    return pipeline;
+}
+
+void RenderPipeline::CreateBuiltinPipelines() {
+    // Built-in pipelines require shader resolver or embedded shaders.
+    // During Phase 17g (migration), the factory will provide the resolver
+    // with built-in SPIR-V/GLSL. For now, we mark pipelines as invalid
+    // and use graceful fallbacks (no crash, just no rendering).
+    //
+    // The pipeline still functions correctly for scene shaders resolved
+    // via the ShaderResolver callback, which is the primary rendering path.
+
+    if (!config_.shaderResolver) return;
+
+    auto* device = config_.device;
+
+    // Get the swapchain render pass for blit/overlay pipelines.
+    // These pipelines render to the screen, not the offscreen target.
+    RHIRenderPass swapPass = device->GetSwapchainRenderPass();
+    if (!swapPass.IsValid()) {
+        // Fall back to offscreen pass (won't be compatible at runtime
+        // but avoids a crash during pipeline creation)
+        swapPass = offscreenPass_;
+    }
+    swapchainPass_ = swapPass;
+
+    // Try to resolve built-in shaders by convention name
+    auto tryCreateBuiltin = [&](const std::string& name,
+                                RHIShader& outVert, RHIShader& outFrag,
+                                RHIPipeline& outPipeline,
+                                const RHIPipelineDesc& baseDesc) {
+        ShaderData sd = config_.shaderResolver(name);
+        if (!sd.vertexCode || !sd.fragCode) return;
+
+        outVert = device->CreateShader(RHIShaderStage::Vertex,
+                                       sd.vertexCode, sd.vertexCodeSize);
+        outFrag = device->CreateShader(RHIShaderStage::Fragment,
+                                       sd.fragCode, sd.fragCodeSize);
+        if (!outVert.IsValid() || !outFrag.IsValid()) return;
+
+        RHIPipelineDesc desc = baseDesc;
+        desc.vertexShader   = outVert;
+        desc.fragmentShader = outFrag;
+        outPipeline = device->CreatePipeline(desc);
+    };
+
+    // -- Blit pipeline (fullscreen quad, no depth) -------------------
+    {
+        RHIPipelineDesc desc{};
+        desc.renderPass     = swapchainPass_;
+        desc.vertexAttrCount = 2;
+        desc.vertexStride    = sizeof(FullscreenVertex);
+        desc.vertexAttrs[0]  = {0, RHIFormat::RG32F, 0};  // position (vec2)
+        desc.vertexAttrs[1]  = {1, RHIFormat::RG32F, 8};  // uv (vec2)
+        desc.topology        = RHITopology::TriangleList;
+        desc.rasterizer      = {RHICullMode::None, RHIFrontFace::CounterClockwise,
+                                RHIPolygonMode::Fill, false};
+        desc.depthStencil    = {false, false, RHICompareOp::Always, false};
+        desc.layoutHint      = RHIPipelineDesc::LayoutHint::Blit;
+        desc.debugName       = "__blit__";
+
+        tryCreateBuiltin("__blit__", blitVertShader_, blitFragShader_,
+                         blitPipeline_, desc);
+    }
+
+    // -- Overlay pipeline (same as blit + alpha blending) ------------
+    {
+        RHIPipelineDesc desc{};
+        desc.renderPass      = swapchainPass_;
+        desc.vertexAttrCount = 2;
+        desc.vertexStride    = sizeof(FullscreenVertex);
+        desc.vertexAttrs[0]  = {0, RHIFormat::RG32F, 0};
+        desc.vertexAttrs[1]  = {1, RHIFormat::RG32F, 8};
+        desc.topology        = RHITopology::TriangleList;
+        desc.rasterizer      = {RHICullMode::None, RHIFrontFace::CounterClockwise,
+                                RHIPolygonMode::Fill, false};
+        desc.depthStencil    = {false, false, RHICompareOp::Always, false};
+        desc.blend.enabled   = true;
+        desc.blend.srcColor  = RHIBlendFactor::SrcAlpha;
+        desc.blend.dstColor  = RHIBlendFactor::OneMinusSrcAlpha;
+        desc.blend.colorOp   = RHIBlendOp::Add;
+        desc.blend.srcAlpha  = RHIBlendFactor::One;
+        desc.blend.dstAlpha  = RHIBlendFactor::OneMinusSrcAlpha;
+        desc.blend.alphaOp   = RHIBlendOp::Add;
+        desc.layoutHint      = RHIPipelineDesc::LayoutHint::Blit;
+        desc.debugName       = "__overlay__";
+
+        tryCreateBuiltin("__overlay__", blitVertShader_, overlayFragShader_,
+                         overlayPipeline_, desc);
+    }
+
+    // -- Debug line pipeline -----------------------------------------
+    {
+        RHIPipelineDesc desc{};
+        desc.renderPass      = offscreenPass_;
+        desc.vertexAttrCount = 2;
+        desc.vertexStride    = sizeof(DebugLineVertex);
+        desc.vertexAttrs[0]  = {0, RHIFormat::RGB32F,  0};      // position (vec3, 12 bytes)
+        desc.vertexAttrs[1]  = {1, RHIFormat::RGBA32F, 12};     // color (vec4, 16 bytes)
+        desc.topology        = RHITopology::LineList;
+        desc.rasterizer      = {RHICullMode::None, RHIFrontFace::CounterClockwise,
+                                RHIPolygonMode::Fill, false};
+        desc.depthStencil    = {true, false, RHICompareOp::Less, false};
+        desc.debugName       = "__debug_line__";
+
+        tryCreateBuiltin("__debug_line__", debugLineVertShader_, debugLineFragShader_,
+                         debugLinePipeline_, desc);
+    }
+
+    // -- Pink error pipeline (constant magenta output) ---------------
+    {
+        RHIPipelineDesc desc{};
+        desc.renderPass      = offscreenPass_;
+        desc.vertexAttrCount = 3;
+        desc.vertexStride    = sizeof(RHIVertex);
+        desc.vertexAttrs[0]  = {0, RHIFormat::RGB32F, 0};
+        desc.vertexAttrs[1]  = {1, RHIFormat::RGB32F, 12};
+        desc.vertexAttrs[2]  = {2, RHIFormat::RG32F,  24};
+        desc.topology        = RHITopology::TriangleList;
+        desc.rasterizer      = {RHICullMode::Back, RHIFrontFace::CounterClockwise,
+                                RHIPolygonMode::Fill, false};
+        desc.depthStencil    = {true, true, RHICompareOp::Less, false};
+        desc.debugName       = "__pink_error__";
+
+        tryCreateBuiltin("__pink_error__", pinkVertShader_, pinkFragShader_,
+                         pinkErrorPipeline_, desc);
+    }
+}
+
+void RenderPipeline::DestroyAllPipelines() {
+    auto* device = config_.device;
+    if (!device) return;
+
+    // Destroy scene pipelines
+    for (auto& [name, pipeline] : scenePipelineCache_) {
+        if (pipeline.IsValid()) device->DestroyPipeline(pipeline);
+    }
+    scenePipelineCache_.clear();
+
+    // Destroy built-in pipelines
+    auto destroy = [&](RHIPipeline& p) {
+        if (p.IsValid()) { device->DestroyPipeline(p); p = {}; }
+    };
+    destroy(blitPipeline_);
+    destroy(overlayPipeline_);
+    destroy(debugLinePipeline_);
+    destroy(pinkErrorPipeline_);
+}
+
+// ── Rendering helpers ──────────────────────────────────────────────────
+
+void RenderPipeline::BuildViewProjection(CameraBase* camera,
+                                          float* viewOut, float* projOut,
+                                          float* cameraPosOut) {
+    // Set base rotation from camera layout
+    camera->GetTransform()->SetBaseRotation(
+        camera->GetCameraLayout()->GetRotation());
+
+    Quaternion lookDir = camera->GetTransform()->GetRotation()
+                             .Multiply(camera->GetLookOffset());
+    Vector3D camPos = camera->GetTransform()->GetPosition();
+    Vector3D forward = lookDir.RotateVector({0, 0, -1}); // -Z forward
+    Vector3D up      = lookDir.RotateVector({0, 1, 0});  // +Y up
+
+    // View matrix (LookAt)
+    Matrix4x4 viewMat = Matrix4x4::LookAt(camPos, camPos + forward, up);
+
+    // Projection matrix
+    Vector2D minC = camera->GetCameraMinCoordinate();
+    Vector2D maxC = camera->GetCameraMaxCoordinate();
+    float vpW = maxC.X - minC.X + 1.0f;
+    float vpH = maxC.Y - minC.Y + 1.0f;
+    float aspect = vpW / vpH;
+
+    Matrix4x4 projMat;
+    if (camera->IsPerspective()) {
+        float fovRad = camera->GetFOV() * kPi / 180.0f;
+        projMat = Matrix4x4::Perspective(fovRad, aspect,
+                                          camera->GetNearPlane(),
+                                          camera->GetFarPlane());
+    } else {
+        float halfW = vpW * 0.5f;
+        float halfH = vpH * 0.5f;
+        projMat = Matrix4x4::Orthographic(-halfW, halfW, -halfH, halfH,
+                                            camera->GetNearPlane(),
+                                            camera->GetFarPlane());
+    }
+
+    // Depth range remap: OpenGL [-1,1] -> Vulkan [0,1]
+    if (config_.vulkanDepthRemap) {
+        for (int c = 0; c < 4; ++c) {
+            projMat.M[2][c] = 0.5f * projMat.M[2][c] + 0.5f * projMat.M[3][c];
+        }
+    }
+
+    // Transpose for GPU upload (row-major -> column-major std140)
+    Matrix4x4 viewT = viewMat.Transpose();
+    Matrix4x4 projT = projMat.Transpose();
+
+    std::memcpy(viewOut, &viewT.M[0][0], 64);
+    std::memcpy(projOut, &projT.M[0][0], 64);
+
+    cameraPosOut[0] = camPos.X;
+    cameraPosOut[1] = camPos.Y;
+    cameraPosOut[2] = camPos.Z;
+    cameraPosOut[3] = 0.0f;
+}
+
+void RenderPipeline::RenderMeshes(Scene* scene,
+                                   const float* view, const float* proj,
+                                   const float* cameraPos) {
+    KL_PERF_SCOPE("RenderPipeline.Meshes");
+
+    auto* device = config_.device;
+    unsigned int meshCount = scene->GetMeshCount();
+    Mesh**       meshes    = scene->GetMeshes();
+
+    RHIPipeline lastPipeline{};
+
+    for (unsigned int i = 0; i < meshCount; ++i) {
+        Mesh* mesh = meshes[i];
+        if (!mesh || !mesh->IsEnabled()) continue;
+
+        ITriangleGroup* triGroup = mesh->GetTriangleGroup();
+        if (!triGroup || triGroup->GetTriangleCount() == 0) continue;
+
+        IMaterial* material = mesh->GetMaterial();
+        if (!material) continue;
+
+        // Resolve pipeline via MaterialBinder
+        KSLMaterial* kmat = material->IsKSL()
+            ? static_cast<KSLMaterial*>(material) : nullptr;
+
+        RHIPipeline pipeline{};
+        const MaterialBinding* binding = nullptr;
+
+        if (kmat && kmat->IsBound() && kmat->GetModule()) {
+            binding = materialBinder_->Bind(kmat);
+            if (binding && binding->valid) {
+                pipeline = binding->pipeline;
+            }
+        }
+
+        if (!pipeline.IsValid()) {
+            pipeline = pinkErrorPipeline_;
+        }
+        if (!pipeline.IsValid()) continue;
+
+        // Bind pipeline (cached to minimize state changes)
+        if (pipeline != lastPipeline) {
+            device->BindPipeline(pipeline);
+            lastPipeline = pipeline;
+        }
+
+        // Upload per-mesh transform
+        // NOTE: Vertex data is already in world space (baked by
+        // Mesh::UpdateTransform on the CPU side).  We use an identity
+        // model matrix so the GPU doesn't apply the transform twice.
+        {
+            TransformUBO ubo{};
+            for (int i = 0; i < 4; ++i) ubo.model[i * 4 + i] = 1.0f;
+            std::memcpy(ubo.view, view, 64);
+            std::memcpy(ubo.projection, proj, 64);
+            std::memcpy(ubo.cameraPos, cameraPos, 16);
+            device->UpdateBuffer(transformUBO_, &ubo, sizeof(ubo));
+            device->BindUniformBuffer(transformUBO_, 0, 0);
+        }
+
+        // Bind material UBO (set 1)
+        if (binding && binding->valid) {
+            device->BindUniformBuffer(binding->uniformBuffer, 1, 0,
+                                      0, binding->uniformSize);
+        }
+
+        // Bind texture (set 2)
+        if (kmat && kmat->TextureCount() > 0) {
+            Texture* tex = kmat->GetTexture(0);
+            if (tex) {
+                RHITexture gpuTex = textureCache_->GetOrUpload(tex);
+                if (gpuTex.IsValid()) {
+                    device->BindTexture(gpuTex, 2, 0);
+                }
+            }
+        }
+
+        // Upload mesh and draw
+        const CachedMesh* cached = meshCache_->GetOrUpload(mesh);
+        if (cached && cached->vertexBuffer.IsValid()) {
+            device->BindVertexBuffer(cached->vertexBuffer);
+            device->Draw(cached->vertexCount);
+        }
+    }
+}
+
+void RenderPipeline::RenderDebugLines(const float* view, const float* proj) {
+    KL_PERF_SCOPE("RenderPipeline.DebugLines");
+
+    auto& dd = DebugDraw::GetInstance();
+    if (!dd.IsEnabled()) return;
+
+    const auto& lines = dd.GetLines();
+    if (lines.empty() || !debugLinePipeline_.IsValid() || !debugLineVBO_.IsValid())
+        return;
+
+    auto* device = config_.device;
+
+    // Build vertex data: depth-tested lines first, then non-depth-tested
+    std::vector<DebugLineVertex> verts;
+    verts.reserve(lines.size() * 2);
+
+    size_t depthTestedCount = 0;
+    for (const auto& line : lines) {
+        if (line.depthTest) {
+            verts.push_back({line.start.X, line.start.Y, line.start.Z,
+                             line.color.r, line.color.g, line.color.b, line.color.a});
+            verts.push_back({line.end.X, line.end.Y, line.end.Z,
+                             line.color.r, line.color.g, line.color.b, line.color.a});
+            depthTestedCount += 2;
+        }
+    }
+
+    // Non-depth-tested lines (TODO: use separate no-depth pipeline)
+    for (const auto& line : lines) {
+        if (!line.depthTest) {
+            verts.push_back({line.start.X, line.start.Y, line.start.Z,
+                             line.color.r, line.color.g, line.color.b, line.color.a});
+            verts.push_back({line.end.X, line.end.Y, line.end.Z,
+                             line.color.r, line.color.g, line.color.b, line.color.a});
+        }
+    }
+
+    if (verts.empty()) return;
+
+    // Clamp to max buffer size
+    size_t uploadCount = std::min(verts.size(), kMaxDebugLineVerts);
+    size_t uploadSize  = uploadCount * sizeof(DebugLineVertex);
+    device->UpdateBuffer(debugLineVBO_, verts.data(), uploadSize);
+
+    // Upload view/projection for line shader via transform UBO
+    // (reuse transform UBO with identity model)
+    {
+        TransformUBO ubo{};
+        for (int i = 0; i < 4; ++i) ubo.model[i * 4 + i] = 1.0f;
+        std::memcpy(ubo.view, view, 64);
+        std::memcpy(ubo.projection, proj, 64);
+        device->UpdateBuffer(transformUBO_, &ubo, sizeof(ubo));
+        device->BindUniformBuffer(transformUBO_, 0, 0);
+    }
+
+    device->BindPipeline(debugLinePipeline_);
+    device->BindVertexBuffer(debugLineVBO_);
+
+    // Draw depth-tested lines
+    if (depthTestedCount > 0 && depthTestedCount <= uploadCount) {
+        device->Draw(static_cast<uint32_t>(depthTestedCount));
+    }
+
+    // Draw non-depth-tested lines (drawn after, on top of everything)
+    size_t noDepthCount = uploadCount - std::min(depthTestedCount, uploadCount);
+    if (noDepthCount > 0) {
+        // TODO: In 17g, ideally switch to a no-depth-test pipeline variant
+        // for the second draw call. For now, all lines use the same pipeline.
+        device->Draw(static_cast<uint32_t>(noDepthCount),
+                     1,
+                     static_cast<uint32_t>(depthTestedCount));
+    }
+}
+
+void RenderPipeline::UploadLights(Scene* scene) {
+    KL_PERF_SCOPE("RenderPipeline.Lights");
+
+    auto* device = config_.device;
+
+    // Collect lights from the first KSL material that has lights
+    // (matching existing Vulkan backend behavior)
+    int lightCount = 0;
+    GPULight gpuLights[kMaxGPULights] = {};
+
+    unsigned int meshCount = scene->GetMeshCount();
+    Mesh** meshes = scene->GetMeshes();
+    for (unsigned int i = 0; i < meshCount && lightCount == 0; ++i) {
+        if (!meshes[i] || !meshes[i]->GetMaterial()) continue;
+        IMaterial* mat = meshes[i]->GetMaterial();
+        if (!mat->IsKSL()) continue;
+
+        auto* kmat = static_cast<KSLMaterial*>(mat);
+        const auto& lights = kmat->GetLights();
+        lightCount = static_cast<int>(
+            std::min(lights.size(), static_cast<size_t>(kMaxGPULights)));
+
+        for (int li = 0; li < lightCount; ++li) {
+            const auto& ld = lights[li];
+            gpuLights[li].position[0] = ld.position.x;
+            gpuLights[li].position[1] = ld.position.y;
+            gpuLights[li].position[2] = ld.position.z;
+            gpuLights[li].intensity   = ld.intensity;
+            gpuLights[li].color[0]    = ld.color.x;
+            gpuLights[li].color[1]    = ld.color.y;
+            gpuLights[li].color[2]    = ld.color.z;
+            gpuLights[li].falloff     = ld.falloff;
+            gpuLights[li].curve       = ld.curve;
+        }
+    }
+
+    // Upload scene UBO (light count) — binding 2 matches SPIR-V layout
+    SceneUBO sceneData{};
+    sceneData.lightCount = lightCount;
+    device->UpdateBuffer(sceneUBO_, &sceneData, sizeof(sceneData));
+    device->BindUniformBuffer(sceneUBO_, 0, 2);
+
+    // Upload light data — binding 1 matches SPIR-V layout (LightBuffer SSBO)
+    // Always bind even if empty — all 4 set-0 descriptors must be valid
+    if (lightCount > 0) {
+        device->UpdateBuffer(lightSSBO_, gpuLights,
+                             sizeof(GPULight) * lightCount);
+    }
+    device->BindUniformBuffer(lightSSBO_, 0, 1, 0,
+                              sizeof(GPULight) * kMaxGPULights);
+
+    // Binding 3: audio SSBO (dummy, required by scene set layout)
+    device->BindUniformBuffer(audioSSBO_, 0, 3);
+}
+
+void RenderPipeline::DrawFullscreenQuad(RHIPipeline pipeline,
+                                         RHITexture texture,
+                                         float alpha) {
+    if (!pipeline.IsValid() || !fullscreenQuadVBO_.IsValid()) return;
+
+    auto* device = config_.device;
+
+    device->BindPipeline(pipeline);
+    device->BindVertexBuffer(fullscreenQuadVBO_);
+
+    if (texture.IsValid()) {
+        device->BindTexture(texture, 0, 0);
+    }
+
+    // Upload alpha uniform for overlay blending
+    if (alpha < 1.0f) {
+        float alphaData[4] = {alpha, 0.0f, 0.0f, 0.0f};
+        device->UpdateBuffer(overlayUBO_, alphaData, sizeof(alphaData));
+        device->BindUniformBuffer(overlayUBO_, 1, 0);
+    }
+
+    device->Draw(6); // 2 triangles
+}
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/render_pipeline.hpp
+++ b/engine/koilo/systems/render/pipeline/render_pipeline.hpp
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file render_pipeline.hpp
+ * @brief Unified GPU render pipeline using the RHI abstraction layer.
+ *
+ * Implements IGPURenderBackend by delegating all GPU operations through
+ * IRHIDevice.  Owns MeshCache, TextureCache, and MaterialBinder for
+ * shared resource management.  Replaces the duplicated scene traversal,
+ * sky rendering, debug line, overlay compositing, and blit logic that
+ * previously lived in both the OpenGL and Vulkan render backends.
+ *
+ * The pipeline is backend-agnostic - it works with any IRHIDevice
+ * implementation (Vulkan, OpenGL, or future backends).
+ *
+ * @date 03/19/2026
+ * @author Coela Can't
+ */
+#pragma once
+
+#include "../igpu_render_backend.hpp"
+#include "../rhi/rhi_types.hpp"
+#include "mesh_cache.hpp"
+#include "texture_cache.hpp"
+#include "material_binder.hpp"
+#include "../../../registry/reflect_macros.hpp"
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <memory>
+#include <vector>
+
+namespace koilo      { class Scene; class CameraBase; class KSLMaterial; }
+namespace koilo::rhi { class IRHIDevice; }
+namespace ksl        { class KSLRegistry; }
+
+namespace koilo::rhi {
+
+// -- Shader data resolved by the factory for a given KSL shader name ----
+struct ShaderData {
+    const void* vertexCode     = nullptr;
+    size_t      vertexCodeSize = 0;
+    const void* fragCode       = nullptr;
+    size_t      fragCodeSize   = 0;
+};
+
+/// Callback that resolves shader bytecode for a KSL shader name.
+/// For Vulkan: provides SPIR-V. For OpenGL: provides GLSL source.
+using ShaderResolver = std::function<ShaderData(const std::string& name)>;
+
+// -- Configuration ------------------------------------------------------
+
+struct RenderPipelineConfig {
+    IRHIDevice*       device        = nullptr;
+    ksl::KSLRegistry* shaderRegistry = nullptr;
+    ShaderResolver    shaderResolver;
+
+    /// Apply Vulkan depth range remap: [-1,1] -> [0,1] on projection matrix.
+    bool vulkanDepthRemap = false;
+
+    /// Initial off-screen render target dimensions (resized dynamically).
+    uint32_t initialWidth  = 1920;
+    uint32_t initialHeight = 1080;
+
+    KL_BEGIN_FIELDS(RenderPipelineConfig)
+        KL_FIELD(RenderPipelineConfig, initialWidth, "Initial width", 0, 4294967295),
+        KL_FIELD(RenderPipelineConfig, initialHeight, "Initial height", 0, 4294967295)
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(RenderPipelineConfig)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(RenderPipelineConfig)
+        /* No reflected ctors. */
+    KL_END_DESCRIBE(RenderPipelineConfig)
+
+};
+
+// -- GPU UBO layouts (std140-compatible) --------------------------------
+
+struct alignas(16) TransformUBO {
+    float model[16];
+    float view[16];
+    float projection[16];
+    float cameraPos[4]; // xyz + pad
+    float inverseViewProj[16]; // for shaders that reconstruct view direction
+};
+
+struct alignas(16) SceneUBO {
+    int   lightCount;
+    int   pad[3];
+};
+
+struct alignas(16) GPULight {
+    float position[3];
+    float intensity;
+    float color[3];
+    float falloff;
+    float curve;
+    float pad[3];
+};
+
+static constexpr int kMaxGPULights = 16;
+
+// -- Debug line vertex (position + color) -------------------------------
+
+struct DebugLineVertex {
+    float px, py, pz;
+    float r, g, b, a;
+
+    KL_BEGIN_FIELDS(DebugLineVertex)
+        KL_FIELD(DebugLineVertex, pz, "Pz", 0, 0),
+        KL_FIELD(DebugLineVertex, a, "A", 0, 0)
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(DebugLineVertex)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(DebugLineVertex)
+        /* No reflected ctors. */
+    KL_END_DESCRIBE(DebugLineVertex)
+
+};
+
+// -- Fullscreen quad vertex (position + UV) -----------------------------
+
+struct FullscreenVertex {
+    float px, py;
+    float u, v;
+
+    KL_BEGIN_FIELDS(FullscreenVertex)
+        KL_FIELD(FullscreenVertex, py, "Py", 0, 0),
+        KL_FIELD(FullscreenVertex, v, "V", 0, 0)
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(FullscreenVertex)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(FullscreenVertex)
+        /* No reflected ctors. */
+    KL_END_DESCRIBE(FullscreenVertex)
+
+};
+
+// -- RenderPipeline -----------------------------------------------------
+
+/**
+ * @class RenderPipeline
+ * @brief Unified GPU render pipeline implementing IGPURenderBackend.
+ *
+ * Owns all shared GPU caches and pipeline state.  Scene traversal,
+ * sky rendering, debug lines, and overlay compositing are written once
+ * here instead of being duplicated across backend implementations.
+ */
+class RenderPipeline : public IGPURenderBackend {
+public:
+    RenderPipeline();
+    ~RenderPipeline() override;
+
+    RenderPipeline(const RenderPipeline&)            = delete;
+    RenderPipeline& operator=(const RenderPipeline&) = delete;
+
+    /// Configure the pipeline. Must be called before Initialize().
+    void Configure(const RenderPipelineConfig& config);
+
+    /// Transfer ownership of the IRHIDevice to this pipeline.
+    /// The device will be destroyed on Shutdown().
+    void OwnDevice(std::unique_ptr<IRHIDevice> device);
+
+    /// Transfer ownership of a KSLRegistry to this pipeline.
+    /// The registry will be destroyed on Shutdown().
+    void OwnRegistry(std::unique_ptr<ksl::KSLRegistry> registry);
+
+    // -- IRenderBackend ------------------------------------------------
+    bool        Initialize() override;
+    void        Shutdown() override;
+    bool        IsInitialized() const override;
+    void        Render(Scene* scene, CameraBase* camera) override;
+    void        ReadPixels(Color888* buffer, int width, int height) override;
+    const char* GetName() const override;
+
+    // -- IGPURenderBackend ---------------------------------------------
+    void RenderDirect(Scene* scene, CameraBase* camera) override;
+    void BlitToScreen(int screenW, int screenH) override;
+    void CompositeCanvasOverlays(int screenW, int screenH) override;
+    void PrepareFrame() override;
+    void FinishFrame() override;
+
+private:
+    // -- Off-screen render target management ---------------------------
+
+    void EnsureOffscreenTarget(uint32_t width, uint32_t height);
+    void DestroyOffscreenTarget();
+
+    // -- Pipeline creation / caching ----------------------------------
+
+    RHIPipeline GetOrCreateScenePipeline(const std::string& shaderName,
+                                         const RenderFlags* flags = nullptr);
+    void        CreateBuiltinPipelines();
+    void        DestroyAllPipelines();
+
+    // -- Rendering helpers --------------------------------------------
+
+    void BuildViewProjection(CameraBase* camera,
+                             float* viewOut, float* projOut,
+                             float* cameraPosOut);
+    void RenderMeshes(Scene* scene,
+                      const float* view, const float* proj,
+                      const float* cameraPos);
+    void RenderDebugLines(const float* view, const float* proj);
+    void UploadLights(Scene* scene);
+    void DrawFullscreenQuad(RHIPipeline pipeline, RHITexture texture, float alpha = 1.0f);
+
+    // -- State --------------------------------------------------------
+
+    RenderPipelineConfig config_;
+    bool                 initialized_ = false;
+
+    // Shared caches
+    std::unique_ptr<MeshCache>      meshCache_;
+    std::unique_ptr<TextureCache>   textureCache_;
+    std::unique_ptr<MaterialBinder> materialBinder_;
+
+    // Optionally owned device + registry (factory transfers ownership)
+    std::unique_ptr<IRHIDevice>      ownedDevice_;
+    std::unique_ptr<ksl::KSLRegistry> ownedRegistry_;
+
+    // Off-screen render target
+    RHITexture      offscreenColor_     = {};
+    RHITexture      offscreenDepth_     = {};
+    RHIRenderPass   offscreenPass_      = {};
+    RHIFramebuffer  offscreenFB_        = {};
+    uint32_t        offscreenWidth_     = 0;
+    uint32_t        offscreenHeight_    = 0;
+
+    // Built-in pipelines
+    RHIPipeline blitPipeline_       = {};
+    RHIPipeline overlayPipeline_    = {};
+    RHIPipeline debugLinePipeline_  = {};
+    RHIPipeline pinkErrorPipeline_  = {};
+
+    // Built-in shaders
+    RHIShader blitVertShader_      = {};
+    RHIShader blitFragShader_      = {};
+    RHIShader overlayFragShader_   = {};
+    RHIShader debugLineVertShader_ = {};
+    RHIShader debugLineFragShader_ = {};
+    RHIShader pinkVertShader_      = {};
+    RHIShader pinkFragShader_      = {};
+
+    // Geometry buffers
+    RHIBuffer fullscreenQuadVBO_   = {};  // FullscreenVertex format (blit/overlay)
+    RHIBuffer sceneQuadVBO_        = {};  // RHIVertex format (sky/effects via scene pipeline)
+    RHIBuffer debugLineVBO_        = {};
+
+    // Uniform buffers
+    RHIBuffer transformUBO_        = {};
+    RHIBuffer sceneUBO_            = {};
+    RHIBuffer lightSSBO_           = {};
+    RHIBuffer audioSSBO_           = {};
+    RHIBuffer overlayUBO_          = {};
+
+    // Scene pipeline cache: shader name -> compiled pipeline
+    std::unordered_map<std::string, RHIPipeline> scenePipelineCache_;
+
+    // Render pass for blit / overlay (renders to swapchain)
+    RHIRenderPass   swapchainPass_  = {};
+
+    KL_BEGIN_FIELDS(RenderPipeline)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(RenderPipeline)
+        KL_METHOD_AUTO(RenderPipeline, Shutdown, "Shutdown"),
+        KL_METHOD_AUTO(RenderPipeline, IsInitialized, "Is initialized"),
+        KL_METHOD_AUTO(RenderPipeline, Render, "Render"),
+        KL_METHOD_AUTO(RenderPipeline, ReadPixels, "Read pixels"),
+        KL_METHOD_AUTO(RenderPipeline, GetName, "Get name"),
+        KL_METHOD_AUTO(RenderPipeline, BlitToScreen, "Blit to screen"),
+        KL_METHOD_AUTO(RenderPipeline, CompositeCanvasOverlays, "Composite canvas overlays"),
+        KL_METHOD_AUTO(RenderPipeline, PrepareFrame, "Prepare frame"),
+        KL_METHOD_AUTO(RenderPipeline, FinishFrame, "Finish frame")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(RenderPipeline)
+        KL_CTOR0(RenderPipeline)
+    KL_END_DESCRIBE(RenderPipeline)
+
+};
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/texture_cache.cpp
+++ b/engine/koilo/systems/render/pipeline/texture_cache.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file texture_cache.cpp
+ * @brief Shared GPU texture cache – implementation.
+ *
+ * Converts Palette and RGB888 textures to RGBA8 and uploads them through
+ * the RHI device interface.
+ *
+ * @date 03/18/2026
+ * @author Coela Can't
+ */
+
+#include "texture_cache.hpp"
+#include "../rhi/rhi_device.hpp"
+#include <koilo/assets/image/texture.hpp>
+#include <koilo/core/color/color888.hpp>
+#include <vector>
+
+namespace koilo::rhi {
+
+// --- Lifetime -----------------------------------------------------------
+
+TextureCache::TextureCache(IRHIDevice* device)
+    : device_(device) {}
+
+TextureCache::~TextureCache() { Clear(); }
+
+// --- Query / upload -----------------------------------------------------
+
+RHITexture TextureCache::GetOrUpload(const Texture* texture)
+{
+    if (!texture)
+        return RHITexture{0};
+
+    const uintptr_t key = reinterpret_cast<uintptr_t>(texture);
+
+    // Fast path – already cached.
+    auto it = cache_.find(key);
+    if (it != cache_.end())
+        return it->second;
+
+    const uint32_t w = texture->GetWidth();
+    const uint32_t h = texture->GetHeight();
+    if (w == 0 || h == 0)
+        return RHITexture{0};
+
+    // Convert to RGBA8 (both backends normalise to 4-channel).
+    std::vector<uint8_t> rgba(w * h * 4);
+
+    if (texture->GetFormat() == Texture::Format::RGB888) {
+        const Color888* pixels = texture->GetPixels();
+        for (uint32_t i = 0; i < w * h; ++i) {
+            rgba[i * 4 + 0] = pixels[i].r;
+            rgba[i * 4 + 1] = pixels[i].g;
+            rgba[i * 4 + 2] = pixels[i].b;
+            rgba[i * 4 + 3] = 255;
+        }
+    } else { // Palette mode
+        const uint8_t* indices = texture->GetIndices();
+        const uint8_t* palette = texture->GetPalette();
+        for (uint32_t i = 0; i < w * h; ++i) {
+            const uint8_t idx = indices[i];
+            rgba[i * 4 + 0] = palette[idx * 3 + 0];
+            rgba[i * 4 + 1] = palette[idx * 3 + 1];
+            rgba[i * 4 + 2] = palette[idx * 3 + 2];
+            rgba[i * 4 + 3] = 255;
+        }
+    }
+
+    // Upload through the RHI device.
+    RHITextureDesc desc{};
+    desc.width  = w;
+    desc.height = h;
+    desc.format = RHIFormat::RGBA8_Unorm;
+    desc.usage  = RHITextureUsage::Sampled | RHITextureUsage::TransferDst;
+
+    RHITexture tex = device_->CreateTexture(desc);
+    device_->UpdateTexture(tex, rgba.data(), rgba.size(), w, h);
+
+    cache_[key] = tex;
+    return tex;
+}
+
+// --- Invalidation -------------------------------------------------------
+
+void TextureCache::Invalidate(const Texture* texture)
+{
+    if (!texture)
+        return;
+
+    const uintptr_t key = reinterpret_cast<uintptr_t>(texture);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+        device_->DestroyTexture(it->second);
+        cache_.erase(it);
+    }
+}
+
+void TextureCache::Clear()
+{
+    for (auto& [key, tex] : cache_)
+        device_->DestroyTexture(tex);
+    cache_.clear();
+}
+
+// --- Accessors ----------------------------------------------------------
+
+size_t TextureCache::Size() const { return cache_.size(); }
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/pipeline/texture_cache.hpp
+++ b/engine/koilo/systems/render/pipeline/texture_cache.hpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file texture_cache.hpp
+ * @brief Shared GPU texture cache using the RHI abstraction layer.
+ *
+ * Converts engine Texture assets to RHI texture handles on first use and
+ * caches them so that both the OpenGL and Vulkan backends avoid duplicating
+ * the Texture -> GPU-texture upload logic.
+ *
+ * @date 03/18/2026
+ * @author Coela Can't
+ */
+#pragma once
+
+#include "../rhi/rhi_types.hpp"
+#include <unordered_map>
+#include <cstdint>
+#include "../../../registry/reflect_macros.hpp"
+
+namespace koilo     { class Texture; }
+namespace koilo::rhi { class IRHIDevice; }
+
+namespace koilo::rhi {
+
+// --- TextureCache -------------------------------------------------------
+
+class TextureCache {
+public:
+    explicit TextureCache(IRHIDevice* device);
+    ~TextureCache();
+
+    TextureCache(const TextureCache&)            = delete;
+    TextureCache& operator=(const TextureCache&) = delete;
+
+    /**
+     * @brief  Return the RHI texture for a Texture asset, uploading if needed.
+     * @param  texture  Source engine texture (may be nullptr).
+     * @return RHI handle, or null handle {0} when the texture is null or empty.
+     */
+    RHITexture GetOrUpload(const Texture* texture);
+
+    /**
+     * @brief Remove a single texture from the cache and destroy its GPU resource.
+     * @param texture  The engine texture to invalidate.
+     */
+    void Invalidate(const Texture* texture);
+
+    /**
+     * @brief Destroy every cached GPU texture and clear the cache.
+     */
+    void Clear();
+
+    /**
+     * @brief Number of textures currently held in the cache.
+     */
+    size_t Size() const;
+
+private:
+    IRHIDevice*                          device_;
+    std::unordered_map<uintptr_t, RHITexture> cache_;
+
+    KL_BEGIN_FIELDS(TextureCache)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(TextureCache)
+        /* No reflected methods. */
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(TextureCache)
+        KL_CTOR(TextureCache, IRHIDevice*)
+    KL_END_DESCRIBE(TextureCache)
+
+};
+
+} // namespace koilo::rhi

--- a/engine/koilo/systems/render/render_cvars.cpp
+++ b/engine/koilo/systems/render/render_cvars.cpp
@@ -18,6 +18,7 @@ AutoCVar_Bool  cvar_r_vsync     {"r.vsync",      "Enable vertical sync",        
 AutoCVar_Bool  cvar_r_shadows   {"r.shadows",    "Enable shadow rendering",            true};
 AutoCVar_Bool  cvar_r_drawcalls {"r.drawcalls",  "Show draw call count in HUD",        false};
 AutoCVar_Bool  cvar_r_depthtest {"r.depthtest",  "Enable depth testing",               true};
+AutoCVar_Bool  cvar_r_legacy_backend {"r.legacy_backend", "Use legacy per-backend rendering (bypass unified pipeline)", false};
 
 } // namespace koilo
 

--- a/engine/koilo/systems/render/render_cvars.hpp
+++ b/engine/koilo/systems/render/render_cvars.hpp
@@ -23,5 +23,6 @@ extern AutoCVar_Bool  cvar_r_vsync;
 extern AutoCVar_Bool  cvar_r_shadows;
 extern AutoCVar_Bool  cvar_r_drawcalls;
 extern AutoCVar_Bool  cvar_r_depthtest;
+extern AutoCVar_Bool  cvar_r_legacy_backend;
 
 } // namespace koilo

--- a/engine/koilo/systems/render/rhi/opengl/opengl_rhi_device.cpp
+++ b/engine/koilo/systems/render/rhi/opengl/opengl_rhi_device.cpp
@@ -29,6 +29,8 @@ GLenum OpenGLRHIDevice::ToGLInternalFormat(RHIFormat fmt) {
         case RHIFormat::RG16F:              return GL_RG16F;
         case RHIFormat::RGBA16F:            return GL_RGBA16F;
         case RHIFormat::RGBA32F:            return GL_RGBA32F;
+        case RHIFormat::RGB32F:             return GL_RGB32F;
+        case RHIFormat::RG32F:              return GL_RG32F;
         case RHIFormat::R32F:               return GL_R32F;
         case RHIFormat::D16_Unorm:          return GL_DEPTH_COMPONENT16;
         case RHIFormat::D24_Unorm_S8_Uint:  return GL_DEPTH24_STENCIL8;
@@ -43,8 +45,10 @@ GLenum OpenGLRHIDevice::ToGLPixelFormat(RHIFormat fmt) {
         case RHIFormat::R8_Unorm:
         case RHIFormat::R32F:               return GL_RED;
         case RHIFormat::RG8_Unorm:
-        case RHIFormat::RG16F:              return GL_RG;
-        case RHIFormat::RGB8_Unorm:         return GL_RGB;
+        case RHIFormat::RG16F:
+        case RHIFormat::RG32F:              return GL_RG;
+        case RHIFormat::RGB8_Unorm:
+        case RHIFormat::RGB32F:             return GL_RGB;
         case RHIFormat::RGBA8_Unorm:
         case RHIFormat::RGBA8_SRGB:
         case RHIFormat::RGBA16F:
@@ -137,8 +141,10 @@ GLint OpenGLRHIDevice::VertexAttrComponentCount(RHIFormat fmt) {
         case RHIFormat::R8_Unorm:
         case RHIFormat::R32F:     return 1;
         case RHIFormat::RG8_Unorm:
-        case RHIFormat::RG16F:    return 2;
-        case RHIFormat::RGB8_Unorm: return 3;
+        case RHIFormat::RG16F:
+        case RHIFormat::RG32F:    return 2;
+        case RHIFormat::RGB8_Unorm:
+        case RHIFormat::RGB32F:   return 3;
         case RHIFormat::RGBA8_Unorm:
         case RHIFormat::BGRA8_Unorm:
         case RHIFormat::RGBA16F:
@@ -157,6 +163,8 @@ GLenum OpenGLRHIDevice::VertexAttrGLType(RHIFormat fmt) {
         case RHIFormat::RG16F:
         case RHIFormat::RGBA16F:      return GL_HALF_FLOAT;
         case RHIFormat::R32F:
+        case RHIFormat::RG32F:
+        case RHIFormat::RGB32F:
         case RHIFormat::RGBA32F:      return GL_FLOAT;
         default:                      return GL_FLOAT;
     }
@@ -343,9 +351,10 @@ RHITexture OpenGLRHIDevice::CreateTexture(const RHITextureDesc& desc) {
     }
 
     // Default sampler
+    GLint glFilter = (desc.filter == RHISamplerFilter::Nearest) ? GL_NEAREST : GL_LINEAR;
     glGenSamplers(1, &slot.sampler);
-    glSamplerParameteri(slot.sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    glSamplerParameteri(slot.sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glSamplerParameteri(slot.sampler, GL_TEXTURE_MIN_FILTER, glFilter);
+    glSamplerParameteri(slot.sampler, GL_TEXTURE_MAG_FILTER, glFilter);
     glSamplerParameteri(slot.sampler, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glSamplerParameteri(slot.sampler, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 

--- a/engine/koilo/systems/render/rhi/rhi_device.hpp
+++ b/engine/koilo/systems/render/rhi/rhi_device.hpp
@@ -146,6 +146,19 @@ public:
 
     // -- Swapchain / surface -----------------------------------------
 
+    /// Begin a render pass that targets the swapchain (screen).
+    /// The device manages the swapchain framebuffer internally.
+    /// Default implementation does nothing (override in GPU backends).
+    virtual void BeginSwapchainRenderPass(const RHIClearValue& clear) {
+        (void)clear;
+    }
+
+    /// Get the render pass handle used for swapchain rendering.
+    /// Pipelines that render to the screen (blit, overlay) must be
+    /// created with this render pass for compatibility.
+    /// Returns an invalid handle if the device doesn't support it.
+    virtual RHIRenderPass GetSwapchainRenderPass() const { return {}; }
+
     /// Get current swapchain dimensions.
     virtual void GetSwapchainSize(uint32_t& outWidth,
                                    uint32_t& outHeight) const = 0;

--- a/engine/koilo/systems/render/rhi/rhi_types.hpp
+++ b/engine/koilo/systems/render/rhi/rhi_types.hpp
@@ -60,8 +60,10 @@ enum class RHIFormat : uint8_t {
     // HDR / float
     RG16F,
     RGBA16F,
-    RGBA32F,
     R32F,
+    RG32F,
+    RGB32F,
+    RGBA32F,
     // Depth / stencil
     D16_Unorm,
     D24_Unorm_S8_Uint,
@@ -81,8 +83,10 @@ inline uint8_t RHIFormatBytesPerPixel(RHIFormat fmt) {
         case RHIFormat::BGRA8_SRGB:        return 4;
         case RHIFormat::RG16F:              return 4;
         case RHIFormat::RGBA16F:            return 8;
-        case RHIFormat::RGBA32F:            return 16;
         case RHIFormat::R32F:               return 4;
+        case RHIFormat::RG32F:              return 8;
+        case RHIFormat::RGB32F:             return 12;
+        case RHIFormat::RGBA32F:            return 16;
         case RHIFormat::D16_Unorm:          return 2;
         case RHIFormat::D24_Unorm_S8_Uint:  return 4;
         case RHIFormat::D32F:               return 4;
@@ -146,6 +150,12 @@ inline RHITextureUsage operator&(RHITextureUsage a, RHITextureUsage b) {
 inline bool HasFlag(RHITextureUsage val, RHITextureUsage flag) {
     return (static_cast<uint8_t>(val) & static_cast<uint8_t>(flag)) != 0;
 }
+
+// -- Sampler filter ---------------------------------------------------
+enum class RHISamplerFilter : uint8_t {
+    Nearest,
+    Linear,
+};
 
 // -- Shader stages ---------------------------------------------------
 enum class RHIShaderStage : uint8_t {
@@ -213,6 +223,7 @@ struct RHITextureDesc {
     uint32_t        arrayLayers = 1;
     RHIFormat       format = RHIFormat::RGBA8_Unorm;
     RHITextureUsage usage  = RHITextureUsage::Sampled;
+    RHISamplerFilter filter = RHISamplerFilter::Linear;
     const char*     debugName = nullptr;
 };
 
@@ -243,6 +254,13 @@ struct RHIDepthStencilState {
     bool         stencilTest = false;
 };
 
+/// Render flags derived from shader metadata (depthTest, cullMode, etc.).
+/// Used by the material binder to create pipeline variants automatically.
+struct RenderFlags {
+    RHIDepthStencilState depthStencil = {};
+    RHICullMode          cullMode     = RHICullMode::Back;
+};
+
 /// Graphics pipeline creation descriptor.
 struct RHIPipelineDesc {
     RHIShader       vertexShader   = {};
@@ -261,6 +279,14 @@ struct RHIPipelineDesc {
     RHIDepthStencilState depthStencil = {};
     RHIBlendState        blend        = {};
 
+    // Pipeline layout hint: determines which descriptor set layout to use
+    // Scene = 3-set layout (scene+material+textures), Blit = sampler+optional UBO
+    enum class LayoutHint : uint8_t {
+        Scene = 0,  // Set 0: scene UBO+SSBO, Set 1: material UBO, Set 2: textures
+        Blit  = 1,  // Set 0: sampler, Set 1: optional UBO
+    };
+    LayoutHint layoutHint = LayoutHint::Scene;
+
     const char* debugName = nullptr;
 };
 
@@ -269,6 +295,7 @@ struct RHIColorAttachment {
     RHIFormat  format  = RHIFormat::RGBA8_Unorm;
     RHILoadOp  loadOp  = RHILoadOp::Clear;
     RHIStoreOp storeOp = RHIStoreOp::Store;
+    bool sampleAfterPass = false; // if true, final layout = SHADER_READ_ONLY_OPTIMAL
 };
 
 /// Render pass creation descriptor.

--- a/engine/koilo/systems/render/rhi/vulkan/vulkan_rhi_device.cpp
+++ b/engine/koilo/systems/render/rhi/vulkan/vulkan_rhi_device.cpp
@@ -29,6 +29,8 @@ VkFormat VulkanRHIDevice::ToVkFormat(RHIFormat fmt) {
         case RHIFormat::RG16F:              return VK_FORMAT_R16G16_SFLOAT;
         case RHIFormat::RGBA16F:            return VK_FORMAT_R16G16B16A16_SFLOAT;
         case RHIFormat::RGBA32F:            return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case RHIFormat::RGB32F:             return VK_FORMAT_R32G32B32_SFLOAT;
+        case RHIFormat::RG32F:              return VK_FORMAT_R32G32_SFLOAT;
         case RHIFormat::R32F:               return VK_FORMAT_R32_SFLOAT;
         case RHIFormat::D16_Unorm:          return VK_FORMAT_D16_UNORM;
         case RHIFormat::D24_Unorm_S8_Uint:  return VK_FORMAT_D24_UNORM_S8_UINT;
@@ -114,42 +116,130 @@ bool VulkanRHIDevice::Initialize() {
         return false;
     }
 
-    // Create descriptor pool
+    // Create per-frame descriptor pools (one per frame in flight).
+    // Each frame only resets its own pool after its fence is waited on,
+    // avoiding the race where one frame's pool is reset while the other
+    // frame's command buffer still references its descriptor sets.
     VkDescriptorPoolSize poolSizes[] = {
-        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,         256},
-        {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,  256},
-        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,          64},
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,         512},
+        {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,  64},
+        {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 512},
+        {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,         128},
     };
     VkDescriptorPoolCreateInfo dpInfo{};
     dpInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
     dpInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-    dpInfo.maxSets = 512;
-    dpInfo.poolSizeCount = 3;
+    dpInfo.maxSets = 1024;
+    dpInfo.poolSizeCount = 4;
     dpInfo.pPoolSizes = poolSizes;
-    if (vkCreateDescriptorPool(device_, &dpInfo, nullptr, &descriptorPool_) != VK_SUCCESS) {
-        KL_ERR("RHI", "Failed to create descriptor pool");
-        return false;
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        if (vkCreateDescriptorPool(device_, &dpInfo, nullptr,
+                                   &descriptorPools_[i]) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create descriptor pool %u", i);
+            return false;
+        }
     }
 
-    // Create descriptor set layouts
-    // Set 0: single uniform buffer (scene/transform data)
+    // -- Scene pipeline descriptor set layouts --------------------------
+    // Matches KSL SPIR-V binding conventions:
+    //   Set 0: scene data (transform UBO, light SSBO, scene UBO, audio SSBO)
+    //   Set 1: material UBO
+    //   Set 2: texture samplers (up to 8)
+
+    // Set 0: Scene data - 4 bindings
+    {
+        VkDescriptorSetLayoutBinding bindings[4] = {};
+        // Binding 0: Transform UBO (vertex + fragment)
+        bindings[0].binding = 0;
+        bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        bindings[0].descriptorCount = 1;
+        bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        // Binding 1: Light buffer SSBO (fragment)
+        bindings[1].binding = 1;
+        bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        bindings[1].descriptorCount = 1;
+        bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        // Binding 2: Scene globals UBO (fragment)
+        bindings[2].binding = 2;
+        bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        bindings[2].descriptorCount = 1;
+        bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        // Binding 3: Audio samples SSBO (fragment)
+        bindings[3].binding = 3;
+        bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        bindings[3].descriptorCount = 1;
+        bindings[3].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+        VkDescriptorSetLayoutCreateInfo layoutInfo{};
+        layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layoutInfo.bindingCount = 4;
+        layoutInfo.pBindings = bindings;
+        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &sceneSetLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create scene descriptor set layout");
+            return false;
+        }
+    }
+    // Set 1: Material UBO
     {
         VkDescriptorSetLayoutBinding binding{};
         binding.binding = 0;
         binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         binding.descriptorCount = 1;
-        binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
         VkDescriptorSetLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         layoutInfo.bindingCount = 1;
         layoutInfo.pBindings = &binding;
-        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &uniformLayout_) != VK_SUCCESS) {
-            KL_ERR("RHI", "Failed to create uniform descriptor set layout");
+        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &materialSetLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create material descriptor set layout");
             return false;
         }
     }
-    // Set 1: single combined image sampler
+    // Set 2: Texture samplers (up to 8)
+    {
+        std::array<VkDescriptorSetLayoutBinding, 8> bindings{};
+        for (uint32_t i = 0; i < 8; ++i) {
+            bindings[i].binding = i;
+            bindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            bindings[i].descriptorCount = 1;
+            bindings[i].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        }
+
+        VkDescriptorSetLayoutCreateInfo layoutInfo{};
+        layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layoutInfo.bindingCount = 8;
+        layoutInfo.pBindings = bindings.data();
+        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &textureSetLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create texture descriptor set layout");
+            return false;
+        }
+    }
+    // Scene pipeline layout: 3 sets + push constants
+    {
+        VkDescriptorSetLayout layouts[] = {sceneSetLayout_, materialSetLayout_, textureSetLayout_};
+
+        VkPushConstantRange pushRange{};
+        pushRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+        pushRange.offset = 0;
+        pushRange.size = 128;
+
+        VkPipelineLayoutCreateInfo layoutInfo{};
+        layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        layoutInfo.setLayoutCount = 3;
+        layoutInfo.pSetLayouts = layouts;
+        layoutInfo.pushConstantRangeCount = 1;
+        layoutInfo.pPushConstantRanges = &pushRange;
+
+        if (vkCreatePipelineLayout(device_, &layoutInfo, nullptr,
+                                    &scenePipelineLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create scene pipeline layout");
+            return false;
+        }
+    }
+
+    // -- Blit pipeline descriptor set layouts ---------------------------
+    // Set 0: one combined image sampler (the offscreen color texture)
     {
         VkDescriptorSetLayoutBinding binding{};
         binding.binding = 0;
@@ -161,31 +251,41 @@ bool VulkanRHIDevice::Initialize() {
         layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         layoutInfo.bindingCount = 1;
         layoutInfo.pBindings = &binding;
-        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &textureLayout_) != VK_SUCCESS) {
-            KL_ERR("RHI", "Failed to create texture descriptor set layout");
+        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &blitSamplerLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create blit sampler layout");
             return false;
         }
     }
-
-    // Create default pipeline layout (set 0 = uniform, set 1 = texture, push constants)
+    // Set 1: optional UBO (overlay alpha, etc.)
     {
-        VkDescriptorSetLayout layouts[] = {uniformLayout_, textureLayout_};
+        VkDescriptorSetLayoutBinding binding{};
+        binding.binding = 0;
+        binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        binding.descriptorCount = 1;
+        binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-        VkPushConstantRange pushRange{};
-        pushRange.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-        pushRange.offset = 0;
-        pushRange.size = 128;
+        VkDescriptorSetLayoutCreateInfo layoutInfo{};
+        layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layoutInfo.bindingCount = 1;
+        layoutInfo.pBindings = &binding;
+        if (vkCreateDescriptorSetLayout(device_, &layoutInfo, nullptr, &blitUBOLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create blit UBO layout");
+            return false;
+        }
+    }
+    // Blit pipeline layout: 2 sets
+    {
+        VkDescriptorSetLayout layouts[] = {blitSamplerLayout_, blitUBOLayout_};
 
         VkPipelineLayoutCreateInfo layoutInfo{};
         layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
         layoutInfo.setLayoutCount = 2;
         layoutInfo.pSetLayouts = layouts;
-        layoutInfo.pushConstantRangeCount = 1;
-        layoutInfo.pPushConstantRanges = &pushRange;
+        layoutInfo.pushConstantRangeCount = 0;
 
         if (vkCreatePipelineLayout(device_, &layoutInfo, nullptr,
-                                    &defaultPipelineLayout_) != VK_SUCCESS) {
-            KL_ERR("RHI", "Failed to create default pipeline layout");
+                                    &blitPipelineLayout_) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to create blit pipeline layout");
             return false;
         }
     }
@@ -207,6 +307,26 @@ bool VulkanRHIDevice::Initialize() {
     limits_.maxBoundDescriptorSets = props.limits.maxBoundDescriptorSets;
     limits_.maxSamplers           = props.limits.maxDescriptorSetSamplers;
     limits_.maxAnisotropy         = props.limits.maxSamplerAnisotropy;
+
+    // -- Dynamic uniform ring buffer ----------------------------------
+    // A large HOST_COHERENT buffer shared by all per-draw uniform writes.
+    // Each UpdateBuffer for a uniform buffer writes to the NEXT slice,
+    // so GPU sees per-draw data instead of the last-written overwrite.
+    uniformMinAlign_ = static_cast<uint32_t>(
+        props.limits.minUniformBufferOffsetAlignment);
+    if (uniformMinAlign_ == 0) uniformMinAlign_ = 256;
+    uniformRingSize_ = 4u * 1024u * 1024u; // 4 MB
+    if (!CreateVkBuffer(uniformRingSize_,
+                        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                        VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                        uniformRingBuffer_, uniformRingMemory_)) {
+        KL_ERR("RHI", "Failed to create uniform ring buffer");
+        return false;
+    }
+    vkMapMemory(device_, uniformRingMemory_, 0, uniformRingSize_,
+                0, &uniformRingMapped_);
+    uniformRingOffset_ = 0;
 
     // Query features
     VkPhysicalDeviceFeatures features;
@@ -236,6 +356,27 @@ void VulkanRHIDevice::Shutdown() {
     if (!initialized_) return;
     vkDeviceWaitIdle(device_);
 
+    // Flush all deferred texture deletions across all frame slots
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        for (auto& s : pendingTextureDeletes_[f]) {
+            if (s.sampler != VK_NULL_HANDLE) vkDestroySampler(device_, s.sampler, nullptr);
+            if (s.view != VK_NULL_HANDLE)    vkDestroyImageView(device_, s.view, nullptr);
+            if (s.image != VK_NULL_HANDLE)   vkDestroyImage(device_, s.image, nullptr);
+            if (s.memory != VK_NULL_HANDLE)  vkFreeMemory(device_, s.memory, nullptr);
+        }
+        pendingTextureDeletes_[f].clear();
+    }
+
+    // Flush all deferred buffer deletions across all frame slots
+    for (uint32_t f = 0; f < kMaxFramesInFlight; ++f) {
+        for (auto& s : pendingBufferDeletes_[f]) {
+            if (s.mapped)  vkUnmapMemory(device_, s.memory);
+            if (s.buffer != VK_NULL_HANDLE) vkDestroyBuffer(device_, s.buffer, nullptr);
+            if (s.memory != VK_NULL_HANDLE) vkFreeMemory(device_, s.memory, nullptr);
+        }
+        pendingBufferDeletes_[f].clear();
+    }
+
     // Destroy all remaining resources
     for (uint32_t i = 1; i < static_cast<uint32_t>(framebuffers_.slots.size()); ++i) {
         auto& s = framebuffers_.slots[i];
@@ -250,6 +391,8 @@ void VulkanRHIDevice::Shutdown() {
             vkDestroyPipelineLayout(device_, s.layout, nullptr);
     }
     for (uint32_t i = 1; i < static_cast<uint32_t>(renderPasses_.slots.size()); ++i) {
+        // Skip the swapchain pass - its VkRenderPass is owned by the display
+        if (swapchainPassHandle_.IsValid() && i == swapchainPassHandle_.id) continue;
         auto& s = renderPasses_.slots[i];
         if (s.pass != VK_NULL_HANDLE)
             vkDestroyRenderPass(device_, s.pass, nullptr);
@@ -273,15 +416,40 @@ void VulkanRHIDevice::Shutdown() {
         if (s.memory != VK_NULL_HANDLE) vkFreeMemory(device_, s.memory, nullptr);
     }
 
-    // Destroy infrastructure
-    if (defaultPipelineLayout_ != VK_NULL_HANDLE)
-        vkDestroyPipelineLayout(device_, defaultPipelineLayout_, nullptr);
-    if (uniformLayout_ != VK_NULL_HANDLE)
-        vkDestroyDescriptorSetLayout(device_, uniformLayout_, nullptr);
-    if (textureLayout_ != VK_NULL_HANDLE)
-        vkDestroyDescriptorSetLayout(device_, textureLayout_, nullptr);
-    if (descriptorPool_ != VK_NULL_HANDLE)
-        vkDestroyDescriptorPool(device_, descriptorPool_, nullptr);
+    // Destroy the uniform ring buffer
+    if (uniformRingMapped_) {
+        vkUnmapMemory(device_, uniformRingMemory_);
+        uniformRingMapped_ = nullptr;
+    }
+    if (uniformRingBuffer_ != VK_NULL_HANDLE) {
+        vkDestroyBuffer(device_, uniformRingBuffer_, nullptr);
+        uniformRingBuffer_ = VK_NULL_HANDLE;
+    }
+    if (uniformRingMemory_ != VK_NULL_HANDLE) {
+        vkFreeMemory(device_, uniformRingMemory_, nullptr);
+        uniformRingMemory_ = VK_NULL_HANDLE;
+    }
+
+    // Destroy pipeline layouts
+    if (scenePipelineLayout_ != VK_NULL_HANDLE)
+        vkDestroyPipelineLayout(device_, scenePipelineLayout_, nullptr);
+    if (blitPipelineLayout_ != VK_NULL_HANDLE)
+        vkDestroyPipelineLayout(device_, blitPipelineLayout_, nullptr);
+    // Destroy descriptor set layouts
+    if (sceneSetLayout_ != VK_NULL_HANDLE)
+        vkDestroyDescriptorSetLayout(device_, sceneSetLayout_, nullptr);
+    if (materialSetLayout_ != VK_NULL_HANDLE)
+        vkDestroyDescriptorSetLayout(device_, materialSetLayout_, nullptr);
+    if (textureSetLayout_ != VK_NULL_HANDLE)
+        vkDestroyDescriptorSetLayout(device_, textureSetLayout_, nullptr);
+    if (blitSamplerLayout_ != VK_NULL_HANDLE)
+        vkDestroyDescriptorSetLayout(device_, blitSamplerLayout_, nullptr);
+    if (blitUBOLayout_ != VK_NULL_HANDLE)
+        vkDestroyDescriptorSetLayout(device_, blitUBOLayout_, nullptr);
+    for (uint32_t i = 0; i < kMaxFramesInFlight; ++i) {
+        if (descriptorPools_[i] != VK_NULL_HANDLE)
+            vkDestroyDescriptorPool(device_, descriptorPools_[i], nullptr);
+    }
     if (frameFence_ != VK_NULL_HANDLE)
         vkDestroyFence(device_, frameFence_, nullptr);
     if (cmdPool_ != VK_NULL_HANDLE)
@@ -512,6 +680,7 @@ RHIBuffer VulkanRHIDevice::CreateBuffer(const RHIBufferDesc& desc) {
     BufferSlot slot{};
     slot.size = desc.size;
     slot.hostVisible = desc.hostVisible;
+    slot.isUniform = HasFlag(desc.usage, RHIBufferUsage::Uniform);
 
     if (!CreateVkBuffer(desc.size, vkUsage, memProps, slot.buffer, slot.memory)) {
         KL_ERR("RHI", "Failed to create buffer (%s)", desc.debugName ? desc.debugName : "unnamed");
@@ -524,9 +693,18 @@ RHIBuffer VulkanRHIDevice::CreateBuffer(const RHIBufferDesc& desc) {
 void VulkanRHIDevice::DestroyBuffer(RHIBuffer handle) {
     if (!handle.IsValid() || !buffers_.Valid(handle.id)) return;
     auto& s = buffers_.Get(handle.id);
-    if (s.mapped) { vkUnmapMemory(device_, s.memory); s.mapped = nullptr; }
-    if (s.buffer != VK_NULL_HANDLE) vkDestroyBuffer(device_, s.buffer, nullptr);
-    if (s.memory != VK_NULL_HANDLE) vkFreeMemory(device_, s.memory, nullptr);
+
+    if (frameActive_) {
+        // Defer destruction - command buffer may still reference this buffer.
+        // Queue to the current frame slot's deferred list; it will be flushed
+        // when this slot is reused (after its fence has been waited on).
+        pendingBufferDeletes_[currentPoolIndex_].push_back(s);
+    } else {
+        if (s.mapped) { vkUnmapMemory(device_, s.memory); s.mapped = nullptr; }
+        if (s.buffer != VK_NULL_HANDLE) vkDestroyBuffer(device_, s.buffer, nullptr);
+        if (s.memory != VK_NULL_HANDLE) vkFreeMemory(device_, s.memory, nullptr);
+    }
+
     buffers_.Free(handle.id);
 }
 
@@ -567,10 +745,12 @@ RHITexture VulkanRHIDevice::CreateTexture(const RHITextureDesc& desc) {
     slot.view = CreateVkImageView(slot.image, vkFmt, aspect);
 
     // Create default sampler
+    VkFilter vkFilter = (desc.filter == RHISamplerFilter::Nearest)
+                        ? VK_FILTER_NEAREST : VK_FILTER_LINEAR;
     VkSamplerCreateInfo samplerInfo{};
     samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    samplerInfo.magFilter = VK_FILTER_LINEAR;
-    samplerInfo.minFilter = VK_FILTER_LINEAR;
+    samplerInfo.magFilter = vkFilter;
+    samplerInfo.minFilter = vkFilter;
     samplerInfo.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
     samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
     samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
@@ -584,10 +764,19 @@ RHITexture VulkanRHIDevice::CreateTexture(const RHITextureDesc& desc) {
 void VulkanRHIDevice::DestroyTexture(RHITexture handle) {
     if (!handle.IsValid() || !textures_.Valid(handle.id)) return;
     auto& s = textures_.Get(handle.id);
-    if (s.sampler != VK_NULL_HANDLE) vkDestroySampler(device_, s.sampler, nullptr);
-    if (s.view != VK_NULL_HANDLE)    vkDestroyImageView(device_, s.view, nullptr);
-    if (s.image != VK_NULL_HANDLE)   vkDestroyImage(device_, s.image, nullptr);
-    if (s.memory != VK_NULL_HANDLE)  vkFreeMemory(device_, s.memory, nullptr);
+
+    if (frameActive_) {
+        // Defer destruction - command buffer may still reference this texture.
+        // Queue to the current frame slot's deferred list; it will be flushed
+        // when this slot is reused (after its fence has been waited on).
+        pendingTextureDeletes_[currentPoolIndex_].push_back(s);
+    } else {
+        if (s.sampler != VK_NULL_HANDLE) vkDestroySampler(device_, s.sampler, nullptr);
+        if (s.view != VK_NULL_HANDLE)    vkDestroyImageView(device_, s.view, nullptr);
+        if (s.image != VK_NULL_HANDLE)   vkDestroyImage(device_, s.image, nullptr);
+        if (s.memory != VK_NULL_HANDLE)  vkFreeMemory(device_, s.memory, nullptr);
+    }
+
     textures_.Free(handle.id);
 }
 
@@ -770,6 +959,11 @@ RHIPipeline VulkanRHIDevice::CreatePipeline(const RHIPipelineDesc& desc) {
     if (desc.renderPass.IsValid() && renderPasses_.Valid(desc.renderPass.id))
         vkPass = renderPasses_.Get(desc.renderPass.id).pass;
 
+    // Select pipeline layout based on hint
+    VkPipelineLayout selectedLayout = scenePipelineLayout_;
+    if (desc.layoutHint == RHIPipelineDesc::LayoutHint::Blit)
+        selectedLayout = blitPipelineLayout_;
+
     // Create pipeline
     VkGraphicsPipelineCreateInfo pipelineInfo{};
     pipelineInfo.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
@@ -783,12 +977,12 @@ RHIPipeline VulkanRHIDevice::CreatePipeline(const RHIPipelineDesc& desc) {
     pipelineInfo.pDepthStencilState  = &depthStencil;
     pipelineInfo.pColorBlendState    = &colorBlend;
     pipelineInfo.pDynamicState       = &dynamicState;
-    pipelineInfo.layout              = defaultPipelineLayout_;
+    pipelineInfo.layout              = selectedLayout;
     pipelineInfo.renderPass          = vkPass;
     pipelineInfo.subpass             = 0;
 
     PipelineSlot slot{};
-    slot.layout = defaultPipelineLayout_;
+    slot.layout = selectedLayout;
     slot.ownsLayout = false;
 
     if (vkCreateGraphicsPipelines(device_, VK_NULL_HANDLE, 1, &pipelineInfo,
@@ -798,7 +992,8 @@ RHIPipeline VulkanRHIDevice::CreatePipeline(const RHIPipelineDesc& desc) {
         return {};
     }
 
-    return {pipelines_.Alloc(slot)};
+    uint32_t pipeId = pipelines_.Alloc(slot);
+    return {pipeId};
 }
 
 void VulkanRHIDevice::DestroyPipeline(RHIPipeline handle) {
@@ -828,7 +1023,9 @@ RHIRenderPass VulkanRHIDevice::CreateRenderPass(const RHIRenderPassDesc& desc) {
         att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
         att.initialLayout = (desc.colorAttachments[i].loadOp == RHILoadOp::Load)
             ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
-        att.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        att.finalLayout = desc.colorAttachments[i].sampleAfterPass
+            ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+            : VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
         VkAttachmentReference ref{};
         ref.attachment = static_cast<uint32_t>(attachments.size());
@@ -865,15 +1062,33 @@ RHIRenderPass VulkanRHIDevice::CreateRenderPass(const RHIRenderPassDesc& desc) {
     subpass.pColorAttachments    = colorRefs.data();
     subpass.pDepthStencilAttachment = desc.hasDepth ? &depthRef : nullptr;
 
-    VkSubpassDependency dep{};
-    dep.srcSubpass    = VK_SUBPASS_EXTERNAL;
-    dep.dstSubpass    = 0;
-    dep.srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
-                      | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
-    dep.dstStageMask  = dep.srcStageMask;
-    dep.srcAccessMask = 0;
-    dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
-                      | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    // Check if any attachment needs to transition for shader sampling
+    bool needsSampleTransition = false;
+    for (uint32_t i = 0; i < desc.colorAttachmentCount; ++i)
+        needsSampleTransition |= desc.colorAttachments[i].sampleAfterPass;
+
+    VkSubpassDependency deps[2] = {};
+    uint32_t depCount = 1;
+
+    deps[0].srcSubpass    = VK_SUBPASS_EXTERNAL;
+    deps[0].dstSubpass    = 0;
+    deps[0].srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                          | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    deps[0].dstStageMask  = deps[0].srcStageMask;
+    deps[0].srcAccessMask = 0;
+    deps[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+                          | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+    if (needsSampleTransition) {
+        // Ensure color writes complete before fragment shader reads in a later pass
+        deps[1].srcSubpass    = 0;
+        deps[1].dstSubpass    = VK_SUBPASS_EXTERNAL;
+        deps[1].srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        deps[1].dstStageMask  = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        deps[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        deps[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+        depCount = 2;
+    }
 
     VkRenderPassCreateInfo rpInfo{};
     rpInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
@@ -881,8 +1096,8 @@ RHIRenderPass VulkanRHIDevice::CreateRenderPass(const RHIRenderPassDesc& desc) {
     rpInfo.pAttachments    = attachments.data();
     rpInfo.subpassCount    = 1;
     rpInfo.pSubpasses      = &subpass;
-    rpInfo.dependencyCount = 1;
-    rpInfo.pDependencies   = &dep;
+    rpInfo.dependencyCount = depCount;
+    rpInfo.pDependencies   = deps;
 
     RenderPassSlot slot{};
     if (vkCreateRenderPass(device_, &rpInfo, nullptr, &slot.pass) != VK_SUCCESS) {
@@ -952,10 +1167,29 @@ void VulkanRHIDevice::UpdateBuffer(RHIBuffer handle, const void* data,
     auto& s = buffers_.Get(handle.id);
 
     if (s.hostVisible) {
+        // For uniform buffers during an active frame, also write to the ring
+        // buffer so each draw gets its own slice of data.
+        if (s.isUniform && frameActive_ && uniformRingMapped_) {
+            uint32_t aligned = (uniformRingOffset_ + uniformMinAlign_ - 1)
+                             & ~(uniformMinAlign_ - 1);
+            if (aligned + size <= uniformRingSize_) {
+                std::memcpy(static_cast<uint8_t*>(uniformRingMapped_) + aligned,
+                            data, size);
+                s.ringOffset = aligned;
+                uniformRingOffset_ = static_cast<uint32_t>(aligned + size);
+            }
+            // Fall through to also write to the original buffer so that on
+            // frames where this buffer is NOT UpdateBuffer'd, the fallback
+            // path (ringOffset == UINT32_MAX) reads valid data.
+        }
         void* mapped = nullptr;
-        vkMapMemory(device_, s.memory, offset, size, 0, &mapped);
-        std::memcpy(mapped, data, size);
-        vkUnmapMemory(device_, s.memory);
+        VkResult mapResult = vkMapMemory(device_, s.memory, offset, size, 0, &mapped);
+        if (mapResult == VK_SUCCESS && mapped) {
+            std::memcpy(mapped, data, size);
+            vkUnmapMemory(device_, s.memory);
+        }
+        if (!s.isUniform || s.ringOffset == UINT32_MAX)
+            s.ringOffset = UINT32_MAX; // not ring-backed
     } else {
         // Staging upload
         VkBuffer staging;
@@ -1048,17 +1282,58 @@ void VulkanRHIDevice::UnmapBuffer(RHIBuffer handle) {
 // -- Command recording -----------------------------------------------
 
 void VulkanRHIDevice::BeginFrame() {
-    vkWaitForFences(device_, 1, &frameFence_, VK_TRUE, UINT64_MAX);
-    vkResetFences(device_, 1, &frameFence_);
+    // Acquire the display's command buffer. This waits on the current
+    // frame's fence, guaranteeing that the GPU has finished executing
+    // this frame slot's previous command buffer. After this point,
+    // resources used by that prior submission are safe to reclaim.
+    cmdBuffer_ = display_->BeginFrame();
+    if (!cmdBuffer_) return;
 
-    // Reclaim all descriptor sets allocated during the previous frame.
-    vkResetDescriptorPool(device_, descriptorPool_, 0);
+    // Advance to this frame's descriptor pool (matches display's double-buffering)
+    currentPoolIndex_ = display_->GetCurrentFrame() % kMaxFramesInFlight;
 
-    vkResetCommandBuffer(cmdBuffer_, 0);
+    // Flush deferred texture deletions queued during THIS frame slot's
+    // previous use. The fence wait above guarantees completeness.
+    auto& texDeletions = pendingTextureDeletes_[currentPoolIndex_];
+    for (auto& s : texDeletions) {
+        if (s.sampler != VK_NULL_HANDLE) vkDestroySampler(device_, s.sampler, nullptr);
+        if (s.view != VK_NULL_HANDLE)    vkDestroyImageView(device_, s.view, nullptr);
+        if (s.image != VK_NULL_HANDLE)   vkDestroyImage(device_, s.image, nullptr);
+        if (s.memory != VK_NULL_HANDLE)  vkFreeMemory(device_, s.memory, nullptr);
+    }
+    texDeletions.clear();
 
-    VkCommandBufferBeginInfo beginInfo{};
-    beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    vkBeginCommandBuffer(cmdBuffer_, &beginInfo);
+    // Flush deferred buffer deletions (same lifecycle as textures).
+    auto& bufDeletions = pendingBufferDeletes_[currentPoolIndex_];
+    for (auto& s : bufDeletions) {
+        if (s.mapped)  vkUnmapMemory(device_, s.memory);
+        if (s.buffer != VK_NULL_HANDLE) vkDestroyBuffer(device_, s.buffer, nullptr);
+        if (s.memory != VK_NULL_HANDLE) vkFreeMemory(device_, s.memory, nullptr);
+    }
+    bufDeletions.clear();
+
+    // Reset this frame slot's descriptor pool (safe - fence waited above).
+    vkResetDescriptorPool(device_, descriptorPools_[currentPoolIndex_], 0);
+
+    // Reset active pipeline layout so the first BindUniformBuffer of the
+    // new frame defaults to scenePipelineLayout_ (not the previous frame's
+    // blit layout, which would cause a descriptor type mismatch).
+    activePipelineLayout_ = VK_NULL_HANDLE;
+
+    // Invalidate cached scene set 0 (pool was reset, old sets are gone).
+    cachedSceneSet0_ = VK_NULL_HANDLE;
+    sceneSet0Written_ = 0;
+    sceneSet0Dirty_ = false;
+    sceneSet0Flushed_ = false;
+
+    // Reset uniform ring buffer write head for this frame.
+    uniformRingOffset_ = 0;
+    // Clear per-buffer ring offsets so that buffers not UpdateBuffer'd
+    // this frame fall back to reading from their original VkBuffer.
+    for (size_t i = 1; i < buffers_.slots.size(); ++i) {
+        buffers_.slots[i].ringOffset = UINT32_MAX;
+    }
+
     frameActive_ = true;
 }
 
@@ -1092,8 +1367,23 @@ void VulkanRHIDevice::EndRenderPass() {
 
 void VulkanRHIDevice::BindPipeline(RHIPipeline pipeline) {
     if (!pipeline.IsValid() || !pipelines_.Valid(pipeline.id)) return;
-    vkCmdBindPipeline(cmdBuffer_, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                      pipelines_.Get(pipeline.id).pipeline);
+    auto& slot = pipelines_.Get(pipeline.id);
+    vkCmdBindPipeline(cmdBuffer_, VK_PIPELINE_BIND_POINT_GRAPHICS, slot.pipeline);
+
+    // Invalidate the cached scene set 0 when the EFFECTIVE pipeline layout
+    // changes (e.g. scene - blit or vice-versa).  VK_NULL_HANDLE defaults
+    // to scenePipelineLayout_ in BindUniformBuffer, so a null - scene
+    // transition is NOT a real layout change and must not invalidate.
+    VkPipelineLayout effectiveOld = (activePipelineLayout_ != VK_NULL_HANDLE)
+                                  ? activePipelineLayout_
+                                  : scenePipelineLayout_;
+    if (slot.layout != effectiveOld) {
+        cachedSceneSet0_ = VK_NULL_HANDLE;
+        sceneSet0Written_ = 0;
+        sceneSet0Dirty_ = false;
+        sceneSet0Flushed_ = false;
+    }
+    activePipelineLayout_ = slot.layout;
 }
 
 void VulkanRHIDevice::BindVertexBuffer(RHIBuffer buffer,
@@ -1116,48 +1406,151 @@ void VulkanRHIDevice::BindUniformBuffer(RHIBuffer buffer, uint32_t set,
                                          size_t offset, size_t range) {
     if (!buffer.IsValid() || !buffers_.Valid(buffer.id)) return;
 
-    // Allocate a descriptor set from the pool
-    VkDescriptorSetLayout layout = (set == 0) ? uniformLayout_ : uniformLayout_;
+    VkPipelineLayout pipeLayout = activePipelineLayout_;
+    if (pipeLayout == VK_NULL_HANDLE) pipeLayout = scenePipelineLayout_;
+
+    // Select the correct descriptor set layout for this set index.
+    // For scene layout: set 0=scene, 1=material, 2=textures
+    // For blit layout:  set 0=sampler, 1=UBO
+    VkDescriptorSetLayout dsLayout = VK_NULL_HANDLE;
+    VkDescriptorType descType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    bool useSceneSet0Cache = false;
+
+    if (pipeLayout == blitPipelineLayout_) {
+        dsLayout = (set == 0) ? blitSamplerLayout_ : blitUBOLayout_;
+    } else {
+        // Scene pipeline - determine type by binding:
+        //   Set 0, Binding 1 = SSBO (lights), Binding 3 = SSBO (audio)
+        //   Everything else = UBO
+        if (set == 0) {
+            dsLayout = sceneSetLayout_;
+            useSceneSet0Cache = true;
+            if (binding == 1 || binding == 3)
+                descType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        } else if (set == 1) {
+            dsLayout = materialSetLayout_;
+        } else {
+            dsLayout = textureSetLayout_;
+        }
+    }
+
+    // -- Scene set 0: write-accumulate with deferred bind --------------
+    //
+    // sceneSetLayout_ has 4 bindings (transform, lights, scene, audio)
+    // that are written by separate BindUniformBuffer calls.  We accumulate
+    // writes into one descriptor set and defer vkCmdBindDescriptorSets
+    // until the next Draw/DrawIndexed call (see FlushPendingDescriptorBinds).
+    //
+    // Per-mesh re-binds of the same buffer are skipped entirely: the
+    // descriptor already references the buffer and only its CONTENT
+    // changes (via UpdateBuffer), which doesn't require a descriptor update.
+    if (useSceneSet0Cache) {
+        if (cachedSceneSet0_ == VK_NULL_HANDLE) {
+            VkDescriptorSetAllocateInfo allocInfo{};
+            allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+            allocInfo.descriptorPool = descriptorPools_[currentPoolIndex_];
+            allocInfo.descriptorSetCount = 1;
+            allocInfo.pSetLayouts = &dsLayout;
+
+            if (vkAllocateDescriptorSets(device_, &allocInfo, &cachedSceneSet0_) != VK_SUCCESS) {
+                KL_ERR("RHI", "Failed to allocate scene set 0");
+                return;
+            }
+            sceneSet0Written_ = 0;
+            sceneSet0Dirty_ = true;
+            sceneSet0Flushed_ = false;
+        }
+
+        // Store binding info (indexed by binding number).  All writes are
+        // deferred to FlushPendingDescriptorBinds().
+        //
+        // Ring-backed uniform buffers (those written to the ring buffer by
+        // UpdateBuffer) ALWAYS update here because the ring offset changes
+        // per draw.  Non-ring bindings (lights, scene globals, audio) are
+        // written once and then skipped via the bitmask.
+        auto& s = buffers_.Get(buffer.id);
+        bool usesRing = (s.isUniform && s.ringOffset != UINT32_MAX);
+
+        if (usesRing || !(sceneSet0Written_ & (1u << binding))) {
+            auto& sb = sceneSet0Bindings_[binding];
+            sb.descType = descType;
+            if (usesRing) {
+                sb.bufInfo.buffer = uniformRingBuffer_;
+                sb.bufInfo.offset = s.ringOffset;
+                sb.bufInfo.range  = s.size;
+            } else {
+                sb.bufInfo.buffer = s.buffer;
+                sb.bufInfo.offset = offset;
+                sb.bufInfo.range  = (range > 0)
+                                  ? static_cast<VkDeviceSize>(range) : s.size;
+            }
+
+            sceneSet0Written_ |= (1u << binding);
+            sceneSet0Dirty_ = true;
+        }
+
+        return; // Bind deferred to FlushPendingDescriptorBinds()
+    }
+
+    // -- All other sets: allocate-write-bind per call ------------------
+
     VkDescriptorSetAllocateInfo allocInfo{};
     allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool_;
+    allocInfo.descriptorPool = descriptorPools_[currentPoolIndex_];
     allocInfo.descriptorSetCount = 1;
-    allocInfo.pSetLayouts = &layout;
+    allocInfo.pSetLayouts = &dsLayout;
 
     VkDescriptorSet descSet;
     if (vkAllocateDescriptorSets(device_, &allocInfo, &descSet) != VK_SUCCESS) {
-        KL_ERR("RHI", "Failed to allocate uniform descriptor set");
+        KL_ERR("RHI", "Failed to allocate descriptor set (set=%u, binding=%u)", set, binding);
         return;
     }
 
     auto& s = buffers_.Get(buffer.id);
     VkDescriptorBufferInfo bufInfo{};
-    bufInfo.buffer = s.buffer;
-    bufInfo.offset = offset;
-    bufInfo.range  = (range > 0) ? range : s.size;
+    if (s.isUniform && s.ringOffset != UINT32_MAX) {
+        bufInfo.buffer = uniformRingBuffer_;
+        bufInfo.offset = s.ringOffset;
+        bufInfo.range  = s.size;
+    } else {
+        bufInfo.buffer = s.buffer;
+        bufInfo.offset = offset;
+        bufInfo.range  = (range > 0) ? range : s.size;
+    }
 
     VkWriteDescriptorSet write{};
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     write.dstSet = descSet;
     write.dstBinding = binding;
     write.descriptorCount = 1;
-    write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    write.descriptorType = descType;
     write.pBufferInfo = &bufInfo;
     vkUpdateDescriptorSets(device_, 1, &write, 0, nullptr);
 
     vkCmdBindDescriptorSets(cmdBuffer_, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                            defaultPipelineLayout_, set, 1, &descSet, 0, nullptr);
+                            pipeLayout, set, 1, &descSet, 0, nullptr);
 }
 
 void VulkanRHIDevice::BindTexture(RHITexture texture,
                                    uint32_t set, uint32_t binding) {
     if (!texture.IsValid() || !textures_.Valid(texture.id)) return;
 
+    VkPipelineLayout pipeLayout = activePipelineLayout_;
+    if (pipeLayout == VK_NULL_HANDLE) pipeLayout = scenePipelineLayout_;
+
+    // Select the correct descriptor set layout for texture binding
+    VkDescriptorSetLayout dsLayout = VK_NULL_HANDLE;
+    if (pipeLayout == blitPipelineLayout_) {
+        dsLayout = blitSamplerLayout_;
+    } else {
+        dsLayout = textureSetLayout_;
+    }
+
     VkDescriptorSetAllocateInfo allocInfo{};
     allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    allocInfo.descriptorPool = descriptorPool_;
+    allocInfo.descriptorPool = descriptorPools_[currentPoolIndex_];
     allocInfo.descriptorSetCount = 1;
-    allocInfo.pSetLayouts = &textureLayout_;
+    allocInfo.pSetLayouts = &dsLayout;
 
     VkDescriptorSet descSet;
     if (vkAllocateDescriptorSets(device_, &allocInfo, &descSet) != VK_SUCCESS) {
@@ -1181,7 +1574,7 @@ void VulkanRHIDevice::BindTexture(RHITexture texture,
     vkUpdateDescriptorSets(device_, 1, &write, 0, nullptr);
 
     vkCmdBindDescriptorSets(cmdBuffer_, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                            defaultPipelineLayout_, set, 1, &descSet, 0, nullptr);
+                            pipeLayout, set, 1, &descSet, 0, nullptr);
 }
 
 void VulkanRHIDevice::SetViewport(const RHIViewport& vp) {
@@ -1212,36 +1605,82 @@ void VulkanRHIDevice::PushConstants(RHIShaderStage stages, const void* data,
     if (static_cast<uint8_t>(stages) & static_cast<uint8_t>(RHIShaderStage::Compute))
         vkStages |= VK_SHADER_STAGE_COMPUTE_BIT;
 
-    vkCmdPushConstants(cmdBuffer_, defaultPipelineLayout_, vkStages, offset, size, data);
+    VkPipelineLayout pipeLayout = activePipelineLayout_;
+    if (pipeLayout == VK_NULL_HANDLE) pipeLayout = scenePipelineLayout_;
+    vkCmdPushConstants(cmdBuffer_, pipeLayout, vkStages, offset, size, data);
+}
+
+void VulkanRHIDevice::FlushPendingDescriptorBinds() {
+    if (cachedSceneSet0_ == VK_NULL_HANDLE || !sceneSet0Dirty_) return;
+
+    // If the set was already flushed (written+bound to the command buffer),
+    // we CANNOT call vkUpdateDescriptorSets on it - that violates the
+    // UPDATE_AFTER_BIND rule.  Allocate a fresh set instead.
+    if (sceneSet0Flushed_) {
+        VkDescriptorSet freshSet = VK_NULL_HANDLE;
+        VkDescriptorSetAllocateInfo allocInfo{};
+        allocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        allocInfo.descriptorPool = descriptorPools_[currentPoolIndex_];
+        allocInfo.descriptorSetCount = 1;
+        allocInfo.pSetLayouts = &sceneSetLayout_;
+        if (vkAllocateDescriptorSets(device_, &allocInfo, &freshSet) != VK_SUCCESS) {
+            KL_ERR("RHI", "Failed to re-allocate scene set 0 for deferred writes");
+            return;
+        }
+        cachedSceneSet0_ = freshSet;
+    }
+
+    // Write ALL stored bindings to the (possibly fresh) descriptor set.
+    uint32_t writeCount = 0;
+    VkWriteDescriptorSet writes[kMaxSceneSet0Bindings];
+    for (uint32_t b = 0; b < kMaxSceneSet0Bindings; ++b) {
+        if (!(sceneSet0Written_ & (1u << b))) continue;
+        auto& sb = sceneSet0Bindings_[b];
+        auto& w  = writes[writeCount];
+        w = {};
+        w.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        w.dstSet          = cachedSceneSet0_;
+        w.dstBinding      = b;
+        w.descriptorCount = 1;
+        w.descriptorType  = sb.descType;
+        w.pBufferInfo     = &sb.bufInfo;
+        ++writeCount;
+    }
+    if (writeCount > 0) {
+        vkUpdateDescriptorSets(device_, writeCount, writes, 0, nullptr);
+    }
+
+    VkPipelineLayout pipeLayout = activePipelineLayout_;
+    if (pipeLayout == VK_NULL_HANDLE) pipeLayout = scenePipelineLayout_;
+    vkCmdBindDescriptorSets(cmdBuffer_, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            pipeLayout, 0, 1, &cachedSceneSet0_, 0, nullptr);
+    sceneSet0Dirty_ = false;
+    sceneSet0Flushed_ = true;
 }
 
 void VulkanRHIDevice::Draw(uint32_t vertexCount, uint32_t instanceCount,
                             uint32_t firstVertex, uint32_t firstInstance) {
+    FlushPendingDescriptorBinds();
     vkCmdDraw(cmdBuffer_, vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
 void VulkanRHIDevice::DrawIndexed(uint32_t indexCount, uint32_t instanceCount,
                                    uint32_t firstIndex, int32_t vertexOffset,
                                    uint32_t firstInstance) {
+    FlushPendingDescriptorBinds();
     vkCmdDrawIndexed(cmdBuffer_, indexCount, instanceCount, firstIndex,
                      vertexOffset, firstInstance);
 }
 
 void VulkanRHIDevice::EndFrame() {
-    if (!frameActive_) return;
-    vkEndCommandBuffer(cmdBuffer_);
-
-    VkSubmitInfo submitInfo{};
-    submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submitInfo.commandBufferCount = 1;
-    submitInfo.pCommandBuffers = &cmdBuffer_;
-
-    vkQueueSubmit(graphicsQueue_, 1, &submitInfo, frameFence_);
+    // No-op: the display's SwapOnly() handles command buffer ending,
+    // queue submission with semaphore synchronization, and presentation.
+    // We just clear our frame-active flag so descriptor pool is recycled.
     frameActive_ = false;
 }
 
 void VulkanRHIDevice::Present() {
-    // Presentation is delegated to VulkanBackend display layer
+    // Submit + present via the display backend.
     if (display_) display_->SwapOnly();
 }
 
@@ -1260,6 +1699,31 @@ void VulkanRHIDevice::GetSwapchainSize(uint32_t& outWidth,
 void VulkanRHIDevice::OnResize(uint32_t /*width*/, uint32_t /*height*/) {
     // VulkanBackend handles swapchain recreation internally.
     // This hook is available for future per-resize resource updates.
+}
+
+void VulkanRHIDevice::BeginSwapchainRenderPass(const RHIClearValue& clear) {
+    (void)clear;  // Display's render pass uses its own clear values
+    if (!display_) return;
+
+    // Delegate to the display's swapchain render pass.
+    // The display must be in an active frame (BeginFrame already called).
+    display_->BeginSwapchainRenderPass();
+}
+
+RHIRenderPass VulkanRHIDevice::GetSwapchainRenderPass() const {
+    if (swapchainPassHandle_.IsValid()) return swapchainPassHandle_;
+    if (!display_) return {};
+
+    // Wrap the display's native VkRenderPass in an RHI handle.
+    // The slot is NOT destroyed during Shutdown because the VkRenderPass
+    // is owned by the display backend, not by us.
+    VkRenderPass nativePass = display_->GetRenderPass();
+    if (nativePass == VK_NULL_HANDLE) return {};
+
+    RenderPassSlot slot{};
+    slot.pass = nativePass;
+    swapchainPassHandle_ = {const_cast<VulkanRHIDevice*>(this)->renderPasses_.Alloc(slot)};
+    return swapchainPassHandle_;
 }
 
 } // namespace koilo::rhi

--- a/engine/koilo/systems/render/rhi/vulkan/vulkan_rhi_device.hpp
+++ b/engine/koilo/systems/render/rhi/vulkan/vulkan_rhi_device.hpp
@@ -101,6 +101,8 @@ public:
     void Present() override;
 
     // -- Swapchain ---------------------------------------------------
+    void BeginSwapchainRenderPass(const RHIClearValue& clear) override;
+    RHIRenderPass GetSwapchainRenderPass() const override;
     void GetSwapchainSize(uint32_t& outWidth,
                            uint32_t& outHeight) const override;
     void OnResize(uint32_t width, uint32_t height) override;
@@ -143,7 +145,12 @@ private:
         VkDeviceMemory memory = VK_NULL_HANDLE;
         VkDeviceSize   size   = 0;
         bool           hostVisible = false;
+        bool           isUniform   = false;
         void*          mapped = nullptr;
+        // When a uniform buffer is UpdateBuffer'd during an active frame,
+        // its data is copied into the ring buffer at this offset.
+        // UINT32_MAX means "not ring-backed this frame."
+        uint32_t       ringOffset = UINT32_MAX;
     };
 
     struct TextureSlot {
@@ -201,6 +208,10 @@ private:
     VkCommandBuffer BeginOneShot();
     void            EndOneShot(VkCommandBuffer cmd);
 
+    /// Flush any deferred descriptor set binds (scene set 0) into the
+    /// command buffer.  Must be called before Draw/DrawIndexed.
+    void FlushPendingDescriptorBinds();
+
     static VkFormat       ToVkFormat(RHIFormat fmt);
     static VkBufferUsageFlags ToVkBufferUsage(RHIBufferUsage usage);
 
@@ -218,6 +229,12 @@ private:
     VkFence          frameFence_ = VK_NULL_HANDLE;
     bool             frameActive_ = false;
 
+    // RHI handle wrapping the display's swapchain render pass.
+    // Created lazily in GetSwapchainRenderPass(). Not destroyed
+    // on Shutdown because the underlying VkRenderPass is owned
+    // by the display backend.
+    mutable RHIRenderPass swapchainPassHandle_ = {};
+
     // Slot arrays
     SlotArray<BufferSlot>      buffers_;
     SlotArray<TextureSlot>     textures_;
@@ -229,11 +246,70 @@ private:
     RHIFeature supportedFeatures_ = static_cast<RHIFeature>(0);
     RHILimits  limits_{};
 
-    // Descriptor management (simple single-set layout for now)
-    VkDescriptorPool      descriptorPool_  = VK_NULL_HANDLE;
-    VkDescriptorSetLayout uniformLayout_   = VK_NULL_HANDLE;
-    VkDescriptorSetLayout textureLayout_   = VK_NULL_HANDLE;
-    VkPipelineLayout      defaultPipelineLayout_ = VK_NULL_HANDLE;
+    // Descriptor management - three layouts matching KSL SPIR-V conventions:
+    // Scene:  Set 0 = scene (UBO+SSBO+UBO+SSBO), Set 1 = material UBO, Set 2 = textures
+    // Blit:   Set 0 = sampler, Set 1 = optional UBO
+    static constexpr uint32_t kMaxFramesInFlight = 2;
+    VkDescriptorPool      descriptorPools_[kMaxFramesInFlight] = {};
+    uint32_t              currentPoolIndex_ = 0;
+
+    // Scene pipeline layout (3 descriptor sets)
+    VkDescriptorSetLayout sceneSetLayout_    = VK_NULL_HANDLE; // set 0: 4 bindings
+    VkDescriptorSetLayout materialSetLayout_ = VK_NULL_HANDLE; // set 1: 1 UBO binding
+    VkDescriptorSetLayout textureSetLayout_  = VK_NULL_HANDLE; // set 2: 8 samplers
+    VkPipelineLayout      scenePipelineLayout_ = VK_NULL_HANDLE;
+
+    // Blit pipeline layout (2 descriptor sets)
+    VkDescriptorSetLayout blitSamplerLayout_ = VK_NULL_HANDLE; // set 0: 1 sampler
+    VkDescriptorSetLayout blitUBOLayout_     = VK_NULL_HANDLE; // set 1: 1 UBO
+    VkPipelineLayout      blitPipelineLayout_  = VK_NULL_HANDLE;
+
+    // Currently bound pipeline layout (set by BindPipeline)
+    VkPipelineLayout      activePipelineLayout_ = VK_NULL_HANDLE;
+
+    // Cached scene descriptor set 0 - avoids allocating a new descriptor set
+    // on every BindUniformBuffer(_, 0, _) call.  sceneSetLayout_ has 4 bindings
+    // (transform UBO, light SSBO, scene UBO, audio SSBO) that get written
+    // incrementally across separate BindUniformBuffer calls.  Without caching,
+    // each call would allocate a fresh set with only ONE binding written,
+    // overwriting the previous bind and leaving other bindings uninitialized.
+    //
+    // Fully-deferred pattern:
+    //   1. BindUniformBuffer(_, 0, N): store binding info, mark dirty
+    //   2. Draw()/DrawIndexed(): flush - vkUpdateDescriptorSets + vkCmdBindDescriptorSets
+    //   3. Per-mesh re-binds with same buffer: skip entirely (bitmask no-op)
+    //   4. If new bindings arrive after first flush: allocate fresh set, replay all
+    VkDescriptorSet       cachedSceneSet0_ = VK_NULL_HANDLE;
+    uint32_t              sceneSet0Written_ = 0;  // bitmask of bindings stored
+    bool                  sceneSet0Dirty_  = false; // needs flush
+    bool                  sceneSet0Flushed_ = false; // set was already written+bound
+
+    static constexpr uint32_t kMaxSceneSet0Bindings = 4;
+    struct SceneSet0Binding {
+        VkDescriptorBufferInfo bufInfo{};
+        VkDescriptorType       descType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    };
+    SceneSet0Binding      sceneSet0Bindings_[kMaxSceneSet0Bindings] = {};
+
+    // Deferred texture deletion queue - textures destroyed during a frame are
+    // queued here and actually freed at the start of the NEXT frame that uses
+    // the same pool index (after its fence has been waited on, guaranteeing
+    // the prior command buffer referencing these resources has completed).
+    std::vector<TextureSlot> pendingTextureDeletes_[kMaxFramesInFlight];
+
+    // Deferred buffer deletion queue - same lifecycle as textures.
+    std::vector<BufferSlot> pendingBufferDeletes_[kMaxFramesInFlight];
+
+    // -- Dynamic uniform ring buffer -----------------------------------
+    // Per-draw UBO data (e.g. transform matrices) is written here instead
+    // of overwriting a single shared HOST_COHERENT buffer.  Each draw gets
+    // its own slice of the ring, so the GPU sees correct per-draw data.
+    VkBuffer       uniformRingBuffer_  = VK_NULL_HANDLE;
+    VkDeviceMemory uniformRingMemory_  = VK_NULL_HANDLE;
+    void*          uniformRingMapped_  = nullptr;
+    uint32_t       uniformRingOffset_  = 0;
+    uint32_t       uniformRingSize_    = 0;  // total ring buffer size
+    uint32_t       uniformMinAlign_    = 256; // minUniformBufferOffsetAlignment
 };
 
 } // namespace koilo::rhi

--- a/engine/koilo/systems/render/vk/vulkan_render_backend.cpp
+++ b/engine/koilo/systems/render/vk/vulkan_render_backend.cpp
@@ -1934,14 +1934,46 @@ VkPipeline VulkanRenderBackend::GetPipelineForMaterial(const KSLMaterial* kmat) 
 // ============================================================================
 
 void VulkanRenderBackend::RenderSky(VkCommandBuffer cmd, CameraBase* camera, int vpW, int vpH) {
-    if (!cmd || !camera || !skyVBO_) return;
+    if (!cmd || !camera || !skyVBO_) {
+        static int dbg0 = 0;
+        if (dbg0++ < 3) { FILE* f = fopen("/tmp/vksky.log", "a"); if(f) { fprintf(f, "early-out: cmd=%p cam=%p vbo=%p\n", (void*)cmd, (void*)camera, (void*)skyVBO_); fclose(f); } }
+        return;
+    }
 
     Sky& sky = Sky::GetInstance();
     bool hasSky = sky.IsEnabled() || camera->HasSkyGradient();
-    if (!hasSky) return;
+    if (!hasSky) {
+        static int dbg1 = 0;
+        if (dbg1++ < 3) { FILE* f = fopen("/tmp/vksky.log", "a"); if(f) { fprintf(f, "no sky: enabled=%d gradient=%d\n", (int)sky.IsEnabled(), (int)camera->HasSkyGradient()); fclose(f); } }
+        return;
+    }
 
     KSLMaterial* kmat = sky.GetMaterial();
-    if (!kmat || !kmat->IsBound() || !kmat->GetModule()) return;
+    if (!kmat || !kmat->IsBound() || !kmat->GetModule()) {
+        static int dbg2 = 0;
+        if (dbg2++ < 3) { FILE* f = fopen("/tmp/vksky.log", "a"); if(f) { fprintf(f, "no mat: kmat=%p bound=%d mod=%p\n", (void*)kmat, kmat ? (int)kmat->IsBound() : -1, kmat ? (void*)kmat->GetModule() : nullptr); fclose(f); } }
+        return;
+    }
+    static int dbg3 = 0;
+    if (dbg3++ < 5) {
+        FILE* f = fopen("/tmp/vksky.log", "a");
+        if (f) {
+            void* inst = kmat->GetInstance();
+            ksl::ParamList params = kmat->GetModule()->GetParams();
+            fprintf(f, "rendering: shader=%s inst=%p params=%d\n", kmat->GetModule()->Name().c_str(), inst, params.count);
+            if (inst && params.decls) {
+                auto* src = static_cast<const uint8_t*>(inst);
+                for (int i = 0; i < params.count; ++i) {
+                    const auto& d = params.decls[i];
+                    if (d.type == ksl::ParamType::Vec3) {
+                        const float* fv = reinterpret_cast<const float*>(src + d.offset);
+                        fprintf(f, "  %s = (%.3f, %.3f, %.3f)\n", d.name, fv[0], fv[1], fv[2]);
+                    }
+                }
+            }
+            fclose(f);
+        }
+    }
 
     // Create sky pipeline on first use (no depth test - sky is background)
     if (!skyPipeline_) {
@@ -1987,6 +2019,14 @@ void VulkanRenderBackend::RenderSky(VkCommandBuffer cmd, CameraBase* camera, int
 
 void VulkanRenderBackend::RenderDebugLines(const float* viewMat, const float* projMat) {
     auto& dd = DebugDraw::GetInstance();
+    static int dl_dbg = 0;
+    if (dl_dbg < 5) {
+        FILE* f = fopen("/tmp/vksky.log", "a");
+        if (f) { fprintf(f, "DebugLines: enabled=%d lines=%zu pipeline=%p mapped=%p\n",
+                (int)dd.IsEnabled(), dd.IsEnabled() ? dd.GetLines().size() : 0u,
+                (void*)linePipeline_, (void*)lineUBOMapped_); fclose(f); }
+        dl_dbg++;
+    }
     if (!dd.IsEnabled()) return;
     const auto& lines = dd.GetLines();
     if (lines.empty() || !linePipeline_ || !lineUBOMapped_) return;
@@ -2061,6 +2101,14 @@ void VulkanRenderBackend::RenderDebugLines(const float* viewMat, const float* pr
 
 void VulkanRenderBackend::RenderDirect(Scene* scene, CameraBase* camera) {
     KL_PERF_SCOPE("GPU.Total");
+    static int rd_dbg = 0;
+    if (rd_dbg < 5) {
+        FILE* f = fopen("/tmp/vksky.log", "a");
+        if (f) { fprintf(f, "RenderDirect frame %d: init=%d scene=%p cam=%p is2D=%d\n",
+                rd_dbg, (int)initialized_, (void*)scene, (void*)camera,
+                camera ? (int)camera->Is2D() : -1); fclose(f); }
+    }
+    rd_dbg++;
     if (!initialized_ || !scene || !camera || camera->Is2D()) {
         return;
     }
@@ -2663,12 +2711,13 @@ void VulkanRenderBackend::CompositeCanvasOverlays(int screenW, int screenH) {
 // ============================================================================
 
 void VulkanRenderBackend::PrepareFrame() {
-    // Per-frame resource preparation (descriptor set rotation etc.)
-    // Currently no-op - single-buffered descriptors for simplicity.
+    // Legacy backend: display frame is started lazily in BlitToScreen().
+    // No preparation needed here.
 }
 
 void VulkanRenderBackend::FinishFrame() {
-    // Post-render finalization. Currently no-op.
+    // Submit the display's command buffer and present.
+    if (display_) display_->SwapOnly();
 }
 
 } // namespace koilo

--- a/engine/koilo/systems/render/vk/vulkan_render_backend.hpp
+++ b/engine/koilo/systems/render/vk/vulkan_render_backend.hpp
@@ -18,7 +18,6 @@
 
 #include <koilo/systems/render/igpu_render_backend.hpp>
 #include <koilo/ksl/ksl_registry.hpp>
-#include <koilo/registry/reflect_macros.hpp>
 
 #include <vulkan/vulkan.h>
 
@@ -317,31 +316,6 @@ private:
     void RenderSky(VkCommandBuffer cmd, CameraBase* camera, int vpW, int vpH);
     void RenderDebugLines(const float* viewMat, const float* projMat);
     VkPipeline GetPipelineForMaterial(const KSLMaterial* kmat);
-
-    #ifdef KL_HAVE_VULKAN_BACKEND
-    KL_BEGIN_FIELDS(VulkanRenderBackend)
-        /* No reflected fields. */
-    KL_END_FIELDS
-
-    KL_BEGIN_METHODS(VulkanRenderBackend)
-        KL_METHOD_AUTO(VulkanRenderBackend, Initialize, "Initialize"),
-        KL_METHOD_AUTO(VulkanRenderBackend, Shutdown, "Shutdown"),
-        KL_METHOD_AUTO(VulkanRenderBackend, IsInitialized, "Is initialized"),
-        KL_METHOD_AUTO(VulkanRenderBackend, Render, "Render"),
-        KL_METHOD_AUTO(VulkanRenderBackend, RenderDirect, "Render direct"),
-        KL_METHOD_AUTO(VulkanRenderBackend, ReadPixels, "Read pixels"),
-        KL_METHOD_AUTO(VulkanRenderBackend, GetName, "Get name"),
-        KL_METHOD_AUTO(VulkanRenderBackend, BlitToScreen, "Blit to screen"),
-        KL_METHOD_AUTO(VulkanRenderBackend, CompositeCanvasOverlays, "Composite canvas overlays"),
-        KL_METHOD_AUTO(VulkanRenderBackend, PrepareFrame, "Prepare frame"),
-        KL_METHOD_AUTO(VulkanRenderBackend, FinishFrame, "Finish frame")
-    KL_END_METHODS
-
-    KL_BEGIN_DESCRIBE(VulkanRenderBackend)
-        /* No reflected ctors - requires VulkanBackend* (not reflectable). */
-    KL_END_DESCRIBE(VulkanRenderBackend)
-    #endif
-
 };
 
 } // namespace koilo

--- a/engine/koilo/systems/ui/ui.hpp
+++ b/engine/koilo/systems/ui/ui.hpp
@@ -278,8 +278,6 @@ private:
     KL_DECLARE_FIELDS(UI)
     KL_DECLARE_METHODS(UI)
     KL_DECLARE_DESCRIBE(UI)
-
-
 };
 
 } // namespace koilo

--- a/engine/koilo/systems/ui/ui_module.hpp
+++ b/engine/koilo/systems/ui/ui_module.hpp
@@ -13,6 +13,7 @@
 
 #include <koilo/kernel/unified_module.hpp>
 #include <memory>
+#include "../../registry/reflect_macros.hpp"
 
 namespace koilo {
 
@@ -42,6 +43,24 @@ private:
 
     /// Ensure font is loaded (lazy init).
     void EnsureFont();
+
+    KL_BEGIN_FIELDS(UIModule)
+        /* No reflected fields. */
+    KL_END_FIELDS
+
+    KL_BEGIN_METHODS(UIModule)
+        KL_METHOD_AUTO(UIModule, GetInfo, "Get info"),
+        KL_METHOD_AUTO(UIModule, Initialize, "Initialize"),
+        KL_METHOD_AUTO(UIModule, Update, "Update"),
+        KL_METHOD_AUTO(UIModule, Render, "Render"),
+        KL_METHOD_AUTO(UIModule, Shutdown, "Shutdown"),
+        KL_METHOD_AUTO(UIModule, GetUI, "Get ui")
+    KL_END_METHODS
+
+    KL_BEGIN_DESCRIBE(UIModule)
+        KL_CTOR0(UIModule)
+    KL_END_DESCRIBE(UIModule)
+
 };
 
 } // namespace koilo

--- a/examples/obj_scene/run.sh
+++ b/examples/obj_scene/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Run the OBJ Scene example via the generic koilo runner.
+# Default: Vulkan. Pass --opengl or --software to switch backend.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/obj_scene.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/obj_scene.ks" \
      --title "KoiloEngine - OBJ Scene" "$@"

--- a/examples/scene_3d/run.sh
+++ b/examples/scene_3d/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Run the 3D Scene example via the generic koilo runner.
+# Default: Vulkan. Pass --opengl or --software to switch backend.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/scene_3d.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/scene_3d.ks" \
      --title "KoiloEngine - 3D Scene" "$@"

--- a/examples/space_shooter/run.sh
+++ b/examples/space_shooter/run.sh
@@ -2,5 +2,5 @@
 # Run the Space Shooter example via the generic koilo runner.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/space_shooter.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/space_shooter.ks" \
      --title "KoiloEngine - Space Shooter" --software --vsync "$@"

--- a/examples/stress_test/run.sh
+++ b/examples/stress_test/run.sh
@@ -2,5 +2,5 @@
 # Run the Stress Test example via the generic koilo runner.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/stress_test.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/stress_test.ks" \
      --title "KoiloEngine - Stress Test" "$@"

--- a/examples/syntax_demo/run.sh
+++ b/examples/syntax_demo/run.sh
@@ -2,5 +2,5 @@
 # Run the Syntax Demo example via the generic koilo runner.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/syntax_demo.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/syntax_demo.ks" \
      --title "KoiloEngine - Syntax Demo" "$@"

--- a/examples/ui_demo/run.sh
+++ b/examples/ui_demo/run.sh
@@ -2,5 +2,5 @@
 # Run the UI Demo example via the generic koilo runner.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/ui_demo_kml.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/ui_demo_kml.ks" \
      --title "KoiloEngine - UI Demo" --vsync "$@"

--- a/examples/ui_showcase/run.sh
+++ b/examples/ui_showcase/run.sh
@@ -2,5 +2,5 @@
 # Run the UI Showcase example via the generic koilo runner.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-exec "${REPO_ROOT}/build/koilo" --vulkan --script "${SCRIPT_DIR}/ui_showcase.ks" \
+exec "${REPO_ROOT}/build/koilo" --script "${SCRIPT_DIR}/ui_showcase.ks" \
      --title "KoiloEngine - UI Showcase" "$@"

--- a/scripts/generatereflectionentry.py
+++ b/scripts/generatereflectionentry.py
@@ -114,14 +114,23 @@ def qualify_name(raw: str, txt: str):
             for nm in ns_re2.finditer(txt[:parent_pos]):
                 brace_idx = txt.find('{', nm.end())
                 if brace_idx != -1 and brace_idx < parent_pos:
-                    part2 = txt[nm.end():parent_pos]
-                    if part2.count('{') > part2.count('}'):
-                        for seg in nm.group(1).split('::'):
-                            if seg:
-                                namespaces.append(seg)
+                    # Check if this namespace's opening brace is still open at parent_pos
+                    depth = 1
+                    pos = brace_idx + 1
+                    while pos < len(txt) and depth > 0:
+                        if txt[pos] == '{': depth += 1
+                        elif txt[pos] == '}': depth -= 1
+                        pos += 1
+                    close_pos = pos - 1
+                    if close_pos < parent_pos:
+                        continue  # namespace closed before parent class
+                    for seg in nm.group(1).split('::'):
+                        if seg:
+                            namespaces.append(seg)
             if namespaces:
                 namespaces = [ns for ns in namespaces if ns not in ('std', 'detail')]
-                return '::'.join(namespaces + [nested_name])
+                deduped = list(dict.fromkeys(namespaces))
+                return '::'.join(deduped + [nested_name])
             return nested_name
 
     # fallback: try to detect enclosing namespaces
@@ -130,11 +139,20 @@ def qualify_name(raw: str, txt: str):
     for nm in ns_re.finditer(txt[:decl_pos]):
         brace_idx = txt.find('{', nm.end())
         if brace_idx != -1 and brace_idx < decl_pos:
-            part = txt[nm.end():decl_pos]
-            if part.count('{') > part.count('}'):
-                for seg in nm.group(1).split('::'):
-                    if seg:
-                        namespaces.append(seg)
+            # Check if this namespace's opening brace is still open at decl_pos
+            # by finding the matching closing brace
+            depth = 1
+            pos = brace_idx + 1
+            while pos < len(txt) and depth > 0:
+                if txt[pos] == '{': depth += 1
+                elif txt[pos] == '}': depth -= 1
+                pos += 1
+            close_pos = pos - 1
+            if close_pos < decl_pos:
+                continue  # namespace is closed before declaration, skip it
+            for seg in nm.group(1).split('::'):
+                if seg:
+                    namespaces.append(seg)
 
     if namespaces:
         # Filter out standard library namespaces that may appear in the file
@@ -176,6 +194,15 @@ def is_platform_class(cls_name, candidates):
             if '/koiloapplication.' in rel:
                 return True
             if '/systems/render/engine/' in rel:
+                return True
+            # GPU render backends (conditionally compiled)
+            if '/systems/render/gl/' in rel:
+                return True
+            if '/systems/render/vk/' in rel:
+                return True
+            if '/systems/render/rhi/vulkan/' in rel:
+                return True
+            if '/systems/render/rhi/opengl/' in rel:
                 return True
             # Classes with direct DisplayManager dependency
             if raw in PLATFORM_CLASSES:

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -3,14 +3,17 @@
 layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec4 a_color;
 
-layout(set = 0, binding = 0) uniform LineUBO {
+layout(set = 0, binding = 0) uniform TransformUBO {
+    mat4 u_model;
     mat4 u_view;
     mat4 u_projection;
+    vec4 u_cameraPos;
+    mat4 u_inverseViewProj;
 };
 
 layout(location = 0) out vec4 v_color;
 
 void main() {
     v_color = a_color;
-    gl_Position = u_projection * u_view * vec4(a_position, 1.0);
+    gl_Position = u_projection * u_view * u_model * vec4(a_position, 1.0);
 }

--- a/shaders/sky.ksl.hpp
+++ b/shaders/sky.ksl.hpp
@@ -11,6 +11,12 @@ struct KSL_SkyShader : public ksl::Shader {
         KSL_PARAM(ksl::vec3, bottomColor, "Sky bottom color", 0.0f, 1.0f)
     KSL_PARAMS_END
 
+    KSL_META_BEGIN(KSL_SkyShader)
+        KSL_META_INT("depthTest",  0)
+        KSL_META_INT("depthWrite", 0)
+        KSL_META_INT("cullMode",   0)
+    KSL_META_END
+
     ksl::vec4 shade(const ksl::ShadeInput& in) const override {
         float t = in.uv.y;
         ksl::vec3 c = ksl::mix(bottomColor, topColor, t);

--- a/tools/ksl/ksl_compiler.py
+++ b/tools/ksl/ksl_compiler.py
@@ -106,9 +106,24 @@ def detect_required_attribs(source_path: str) -> int:
     return flags
 
 
+def detect_has_metadata(source_path: str) -> bool:
+    """Check if the shader declares KSL_META_BEGIN."""
+    with open(source_path, "r") as f:
+        content = f.read()
+    return bool(re.search(r'KSL_META_BEGIN', content))
+
+
 def generate_wrapper(shader_include: str, class_name: str, display_name: str,
-                     required_attribs: int = 0xFF) -> str:
+                     required_attribs: int = 0xFF, has_metadata: bool = False) -> str:
     """Generate the C ABI wrapper source code."""
+    metadata_fn = ""
+    if has_metadata:
+        metadata_fn = """
+    const ksl::MetaEntry* ksl_metadata(int* count) {
+        auto m = ShaderType::Meta();
+        *count = m.count;
+        return m.entries;
+    }"""
     return f'''// Auto-generated KSL wrapper - do not edit
 #include <cstdlib>
 #include <cstring>
@@ -177,6 +192,7 @@ extern "C" {{
         *count = p.count;
         return p.decls;
     }}
+{metadata_fn}
 }}
 '''
 
@@ -194,7 +210,9 @@ def compile_kso(source: str, output: str, target: str, compiler: str,
     with tempfile.TemporaryDirectory() as tmpdir:
         wrapper_path = os.path.join(tmpdir, "ksl_wrapper.cpp")
         attribs = detect_required_attribs(source)
-        wrapper_src = generate_wrapper(os.path.basename(source), class_name, display_name, attribs)
+        has_meta = detect_has_metadata(source)
+        wrapper_src = generate_wrapper(os.path.basename(source), class_name,
+                                       display_name, attribs, has_meta)
 
         with open(wrapper_path, "w") as f:
             f.write(wrapper_src)


### PR DESCRIPTION
…es, and clean build fixes.

### Added
- Unified `RenderPipeline` using `IRHIDevice`, replacing duplicated backend scene traversal
- Shared `MeshCache`, `TextureCache`, and `MaterialBinder` for backend-agnostic resource management
- `ShaderResolver` for built-in shader name mapping (blit, overlay, debug line, pink error, sky)
- Deferred descriptor set write pattern for scene set 0 with automatic re-allocation on post-flush writes
- Per-frame deferred buffer and texture deletion queued behind GPU fence waits
- Per-frame descriptor pools (one per frame in flight)
- `sampleAfterPass` flag on `RHIColorAttachment` for render pass final layout control
- `r_backend` CVar for runtime render backend selection
- Swapchain render pass API on `IRHIDevice`
- `build.sh` flags: `--no-vulkan`, `--no-opengl`, `--software-only`, `--skip-ns`, `--debug`
- SDL3Backend fallback display for pure software-only builds (no GL/VK dependency)

### Changed
- Vulkan descriptor set layouts restructured into scene (3 sets) and blit (2 sets) pipelines
- `BindUniformBuffer` fully deferred for scene set 0, no immediate Vulkan calls
- `BindPipeline` uses effective-layout-aware cache invalidation
- `BeginFrame` reordered so fence wait precedes pool reset and deferred deletion flush
- `UploadLights` now runs before `RenderSky` so all set 0 bindings populate before first draw
- KSL modules expose SPIR-V accessors; registry gains `GetModuleByName`
- SDL3Host frame loop updated for RenderFrameGPU -> BlitToScreen -> Overlay -> UI -> Present sequence
- Removed `updatekoiloregistry.py` from CMake build (reflection registry is manual-only now)
- Reflection entry generator classifies GPU backend paths as platform-specific (software-only linker fix)

### Fixed
- Descriptor set 0 incomplete bindings from per-call allocation replaced with deferred accumulation
- Descriptor set updated after bind (UPDATE_AFTER_BIND violation) fixed with fresh-set replay
- Buffer and texture destruction while GPU in-flight via per-frame deferred deletion queues
- Render pipeline binding order causing partial set 0 flushes before lights were uploaded
- Descriptor type mismatch from stale pipeline layout carrying across frames
- Descriptor pool reset while other frame's command buffer still in-flight
- Offscreen-to-blit image layout transition missing proper subpass dependency
- Sky and pink error shader vertex format mismatches
- Overlay rendering outside active render pass
- Texture upload missing TransferDst usage flag
- Broken KL_* reflection macros in 18+ files that prevented clean builds
- Clean build from scratch now works for all backend configurations