### PR TITLE
[0.3.13] Typed services, input events, ECS runtime components, and cu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.13] - 2026-3-30
+Typed services, input events, ECS runtime components, and custom UI widgets.
+
+### Added
+- Typed service registry: `RegisterTyped<T>()`, `Get<T>()` with debug type-safety assertions, `ListByPrefix()` for service discovery (#27)
+- `ICommandProvider` interface - modules declare console commands without coupling to ConsoleModule; discovered via `"commands.*"` prefix scan (#26)
+- Input event system: `KeyEvent`, `MouseButtonEvent`, `MouseMoveEvent`, `ScrollEvent` structs with `IInputListener` priority-based dispatch and consumption (#28)
+- `InputListenerRegistry` registered as `"input.listeners"` kernel service
+- ECS component registry: `IComponentType` / `ComponentType<T>` descriptors, `ComponentRegistry` with runtime ID assignment after compile-time IDs (#29)
+- Widget factory: `IWidgetFactory` / `CustomWidget` / `WidgetTypeRegistry` for module-defined UI widgets rendered via `CanvasDrawContext` (#30)
+- `WidgetTag::Custom` enum value with `customWidget` field on Widget struct
+
+### Changed
+- `ComponentMask` expanded from `bitset<64>` to `bitset<128>`
+- Audio, AI, Physics, and Asset modules migrated from direct `ConsoleModule::Instance()` to `ICommandProvider` pattern
+- `InputManager::Update()` now generates events by diffing current vs previous frame state (polling API unchanged)
+
 ## [0.3.12] - 2026-3-30
 Software RHI rendering fixes: text, scissor clipping, and draw ordering.
 

--- a/engine/koilo/kernel/console/command_provider.hpp
+++ b/engine/koilo/kernel/console/command_provider.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file command_provider.hpp
+ * @brief Interface for modules to declare console commands without
+ *        coupling to ConsoleModule internals.
+ *
+ * Modules implement ICommandProvider and register as a
+ * "commands.<module_name>" typed service. ConsoleModule discovers
+ * all providers via ServiceRegistry prefix scan at init.
+ *
+ * @date 03/30/2026
+ * @author Coela
+ */
+#pragma once
+#include <koilo/kernel/console/command_registry.hpp>
+#include <vector>
+
+namespace koilo {
+
+/// Extension point: modules return their command definitions
+/// without touching ConsoleModule or CommandRegistry directly.
+class ICommandProvider {
+public:
+    virtual ~ICommandProvider() = default;
+
+    /// Return all commands this module provides.
+    virtual std::vector<CommandDef> GetCommands() const = 0;
+};
+
+} // namespace koilo

--- a/engine/koilo/kernel/console/console_module.cpp
+++ b/engine/koilo/kernel/console/console_module.cpp
@@ -1,8 +1,10 @@
 #include <koilo/kernel/console/console_module.hpp>
 #include <koilo/kernel/console/console_commands.hpp>
+#include <koilo/kernel/console/command_provider.hpp>
 #include <koilo/kernel/console/event_bridge.hpp>
 #include <koilo/systems/ui/console_widget.hpp>
 #include <koilo/kernel/kernel.hpp>
+#include <koilo/kernel/logging/log.hpp>
 #include <sstream>
 #include <algorithm>
 #include <iomanip>
@@ -41,6 +43,9 @@ bool ConsoleModule::Init(KoiloKernel& kernel) {
 }
 
 void ConsoleModule::Tick(float /*dt*/) {
+    if (instance_ && !instance_->providersDiscovered_) {
+        instance_->DiscoverProviders();
+    }
     // Update the console widget if it has been built
     if (instance_ && instance_->widget_ && instance_->widget_->IsBuilt()) {
         instance_->widget_->Update();
@@ -69,6 +74,22 @@ void ConsoleModule::Shutdown() {
 
 ConsoleResult ConsoleModule::Execute(const std::string& input) {
     return session_->Execute(input);
+}
+
+void ConsoleModule::DiscoverProviders() {
+    providersDiscovered_ = true;
+    if (!kernel_) return;
+
+    auto names = kernel_->Services().ListByPrefix("commands.");
+    for (const auto& name : names) {
+        auto* provider = kernel_->Services().Get<ICommandProvider>(name);
+        if (!provider) continue;
+        auto cmds = provider->GetCommands();
+        for (auto& def : cmds) {
+            commands_.Register(std::move(def));
+        }
+        KL_DBG("ConsoleModule", "Loaded commands from provider: %s", name.c_str());
+    }
 }
 
 IConsoleWidget* ConsoleModule::Widget() {

--- a/engine/koilo/kernel/console/console_module.hpp
+++ b/engine/koilo/kernel/console/console_module.hpp
@@ -82,6 +82,10 @@ public:
      */
     bool HandleKey(bool isReturn, bool isToggle);
 
+    /// Discover ICommandProvider services registered as "commands.*"
+    /// and merge their commands into the registry.
+    void DiscoverProviders();
+
 private:
     static bool Init(KoiloKernel& kernel);
     static void Tick(float dt);
@@ -94,6 +98,7 @@ private:
     std::unique_ptr<EventBridge> eventBridge_;
     std::unique_ptr<ConsoleWidget> widget_;
     KoiloKernel* kernel_ = nullptr;
+    bool providersDiscovered_ = false;
 
     static std::unique_ptr<ConsoleModule> instance_;
 

--- a/engine/koilo/kernel/service_registry.cpp
+++ b/engine/koilo/kernel/service_registry.cpp
@@ -14,6 +14,9 @@ void ServiceRegistry::Register(const std::string& name, void* service) {
 
 void ServiceRegistry::Unregister(const std::string& name) {
     services_.erase(name);
+#ifndef NDEBUG
+    typeMap_.erase(name);
+#endif
     KL_DBG("ServiceRegistry", "Unregistered service: %s", name.c_str());
     if (bus_) {
         bus_->Send(MakeSignal(MSG_SERVICE_UNREGISTERED));
@@ -34,6 +37,17 @@ std::vector<std::string> ServiceRegistry::List() const {
     names.reserve(services_.size());
     for (auto& [name, _] : services_) {
         names.push_back(name);
+    }
+    return names;
+}
+
+std::vector<std::string> ServiceRegistry::ListByPrefix(const std::string& prefix) const {
+    std::vector<std::string> names;
+    for (auto& [name, _] : services_) {
+        if (name.size() >= prefix.size() &&
+            name.compare(0, prefix.size(), prefix) == 0) {
+            names.push_back(name);
+        }
     }
     return names;
 }

--- a/engine/koilo/kernel/service_registry.hpp
+++ b/engine/koilo/kernel/service_registry.hpp
@@ -7,7 +7,9 @@
  * @author Coela
  */
 #pragma once
+#include <cassert>
 #include <string>
+#include <typeindex>
 #include <vector>
 #include <unordered_map>
 
@@ -28,17 +30,35 @@ public:
     /// Attach a message bus for service lifecycle events.
     void SetBus(MessageBus* bus) { bus_ = bus; }
 
-    /// Register a service. Overwrites if name already registered.
+    /// Register a service (untyped). Overwrites if name already registered.
     void Register(const std::string& name, void* service);
+
+    /// Register a service with type information. Debug builds validate
+    /// type consistency on retrieval; release builds have zero overhead.
+    template<typename T>
+    void RegisterTyped(const std::string& name, T* service) {
+        Register(name, static_cast<void*>(service));
+#ifndef NDEBUG
+        typeMap_.insert_or_assign(name, std::type_index(typeid(T)));
+#endif
+    }
 
     /// Remove a service registration.
     void Unregister(const std::string& name);
 
-    /// Get a service by name. Returns nullptr if not found.
+    /// Get a service by name (untyped cast). Returns nullptr if not found.
     template<typename T>
     T* Get(const std::string& name) const {
         auto it = services_.find(name);
-        return it != services_.end() ? static_cast<T*>(it->second) : nullptr;
+        if (it == services_.end()) return nullptr;
+#ifndef NDEBUG
+        auto ti = typeMap_.find(name);
+        if (ti != typeMap_.end()) {
+            assert(ti->second == std::type_index(typeid(T)) &&
+                   "ServiceRegistry type mismatch: requested type differs from registered type");
+        }
+#endif
+        return static_cast<T*>(it->second);
     }
 
     /// Non-typed get (returns void*). Returns nullptr if not found.
@@ -50,12 +70,18 @@ public:
     /// List all registered service names.
     std::vector<std::string> List() const;
 
+    /// List all service names matching a prefix (e.g. "commands.").
+    std::vector<std::string> ListByPrefix(const std::string& prefix) const;
+
     /// Number of registered services.
     size_t Count() const { return services_.size(); }
 
 private:
     std::unordered_map<std::string, void*> services_;
     MessageBus* bus_ = nullptr;
+#ifndef NDEBUG
+    std::unordered_map<std::string, std::type_index> typeMap_;
+#endif
 };
 
 } // namespace koilo

--- a/engine/koilo/systems/ai/ai_module.cpp
+++ b/engine/koilo/systems/ai/ai_module.cpp
@@ -3,7 +3,6 @@
 #include "script_ai_manager.hpp"
 #include <koilo/scripting/koiloscript_engine.hpp>
 #include <koilo/kernel/kernel.hpp>
-#include <koilo/kernel/console/console_module.hpp>
 
 namespace koilo {
 
@@ -23,22 +22,24 @@ bool AIModule::Initialize(KoiloKernel& kernel) {
     manager_ = std::make_unique<ScriptAIManager>();
     engine->RegisterGlobal("ai", "ScriptAIManager", manager_.get());
 
-    // Register console commands if available
-    auto* console = ConsoleModule::Instance();
-    if (console) {
-        auto& cmds = console->Commands();
-        cmds.Register({"ai", "ai [status|machines|paths]", "AI system info",
-            [this](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
-                if (!manager_) return ConsoleResult::Error("AI module not initialized");
-                if (args.empty() || args[0] == "status") {
-                    return ConsoleResult::Ok("AI module: active");
-                }
-                return ConsoleResult::Error("Unknown subcommand: " + args[0]);
-            }, nullptr
-        });
-    }
+    kernel.Services().RegisterTyped<ICommandProvider>("commands.ai", this);
 
     return true;
+}
+
+std::vector<CommandDef> AIModule::GetCommands() const {
+    std::vector<CommandDef> cmds;
+    auto* mgr = manager_.get();
+    cmds.push_back({"ai", "ai [status|machines|paths]", "AI system info",
+        [mgr](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
+            if (!mgr) return ConsoleResult::Error("AI module not initialized");
+            if (args.empty() || args[0] == "status") {
+                return ConsoleResult::Ok("AI module: active");
+            }
+            return ConsoleResult::Error("Unknown subcommand: " + args[0]);
+        }, nullptr
+    });
+    return cmds;
 }
 
 void AIModule::Update(float dt) {

--- a/engine/koilo/systems/ai/ai_module.hpp
+++ b/engine/koilo/systems/ai/ai_module.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <koilo/kernel/unified_module.hpp>
+#include <koilo/kernel/console/command_provider.hpp>
 #include <memory>
 #include "../../registry/reflect_macros.hpp"
 
@@ -17,7 +18,7 @@ namespace koilo {
 
 class ScriptAIManager;
 
-class AIModule : public IModule {
+class AIModule : public IModule, public ICommandProvider {
 public:
     AIModule();
     ~AIModule() override;
@@ -27,6 +28,9 @@ public:
     void Update(float dt) override;
     void Render(Color888* buffer, int width, int height) override;
     void Shutdown() override;
+
+    // ICommandProvider
+    std::vector<CommandDef> GetCommands() const override;
 
     ScriptAIManager* GetManager() { return manager_.get(); }
 

--- a/engine/koilo/systems/asset/asset_module.cpp
+++ b/engine/koilo/systems/asset/asset_module.cpp
@@ -5,7 +5,6 @@
  */
 #include "asset_module.hpp"
 #include <koilo/kernel/kernel.hpp>
-#include <koilo/kernel/console/console_module.hpp>
 #include <koilo/kernel/logging/log.hpp>
 #include <koilo/scripting/koiloscript_engine.hpp>
 #include <sstream>
@@ -30,9 +29,9 @@ bool AssetModule::Initialize(KoiloKernel& kernel) {
     instance_ = this;
     jobQueue_.SetPool(&kernel.Pool());
     SetupFileWatcher();
-    RegisterConsoleCommands();
 
     kernel.Services().Register("assets", this);
+    kernel.Services().RegisterTyped<ICommandProvider>("commands.asset", this);
 
     // Register with script engine if available.
     auto* engine = kernel.Services().Get<scripting::KoiloScriptEngine>("script");
@@ -314,19 +313,17 @@ size_t AssetModule::GetTotalMemory() const {
     return registry_.TotalMemory();
 }
 
-// -- Console commands ----------------------------------------------
+// -- Console commands (via ICommandProvider) ---------------------------
 
-void AssetModule::RegisterConsoleCommands() {
-    auto* console = ConsoleModule::Instance();
-    if (!console) return;
+std::vector<CommandDef> AssetModule::GetCommands() const {
+    std::vector<CommandDef> result;
+    // Capture mutable this for non-const operations (gc, reload)
+    auto* self = const_cast<AssetModule*>(this);
 
-    auto& cmds = console->Commands();
-
-    cmds.Register({"assets", "assets [list|info|memory|gc|reload] [args...]",
+    result.push_back({"assets", "assets [list|info|memory|gc|reload] [args...]",
         "Asset pipeline management",
-        [this](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
+        [self](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
             if (args.empty() || args[0] == "list") {
-                // Optional type filter: assets list Mesh
                 AssetType filterType = AssetType::Generic;
                 bool hasFilter = false;
                 if (args.size() >= 2) {
@@ -343,7 +340,7 @@ void AssetModule::RegisterConsoleCommands() {
 
                 std::ostringstream ss;
                 size_t count = 0;
-                registry_.ForEach([&](AssetHandle handle, const AssetSlot& slot) {
+                self->registry_.ForEach([&](AssetHandle handle, const AssetSlot& slot) {
                     if (hasFilter && slot.type != filterType) return;
                     ss << "  [" << AssetTypeName(slot.type) << "] "
                        << slot.path << " - " << AssetStateName(slot.state);
@@ -362,12 +359,11 @@ void AssetModule::RegisterConsoleCommands() {
 
             if (args[0] == "info") {
                 if (args.size() < 2) return ConsoleResult::Error("Usage: assets info <path>");
-                AssetHandle h = registry_.FindByPath(args[1]);
+                AssetHandle h = self->registry_.FindByPath(args[1]);
                 if (h.IsNull()) return ConsoleResult::Error("Not found: " + args[1]);
 
-                const AssetSlot* slot = nullptr;
                 std::ostringstream ss;
-                registry_.ForEach([&](AssetHandle handle, const AssetSlot& s) {
+                self->registry_.ForEach([&](AssetHandle handle, const AssetSlot& s) {
                     if (handle == h) {
                         ss << "Path: " << s.path << "\n"
                            << "Type: " << AssetTypeName(s.type) << "\n"
@@ -375,12 +371,12 @@ void AssetModule::RegisterConsoleCommands() {
                            << "Memory: " << s.memoryBytes << " bytes\n"
                            << "Dependencies: " << s.dependencies.size() << "\n";
                         for (AssetHandle dep : s.dependencies) {
-                            ss << "  -> " << registry_.GetPath(dep) << "\n";
+                            ss << "  -> " << self->registry_.GetPath(dep) << "\n";
                         }
-                        auto dependents = registry_.GetDependents(h);
+                        auto dependents = self->registry_.GetDependents(h);
                         ss << "Dependents: " << dependents.size() << "\n";
                         for (AssetHandle dep : dependents) {
-                            ss << "  <- " << registry_.GetPath(dep) << "\n";
+                            ss << "  <- " << self->registry_.GetPath(dep) << "\n";
                         }
                     }
                 });
@@ -388,9 +384,9 @@ void AssetModule::RegisterConsoleCommands() {
             }
 
             if (args[0] == "memory") {
-                size_t total = registry_.TotalMemory();
-                size_t count = registry_.Count();
-                size_t loaded = registry_.CountByState(AssetState::Loaded);
+                size_t total = self->registry_.TotalMemory();
+                size_t count = self->registry_.Count();
+                size_t loaded = self->registry_.CountByState(AssetState::Loaded);
                 std::ostringstream ss;
                 ss << "Assets: " << count << " registered, " << loaded << " loaded\n"
                    << "Memory: " << total << " bytes ("
@@ -400,32 +396,32 @@ void AssetModule::RegisterConsoleCommands() {
             }
 
             if (args[0] == "gc") {
-                size_t freed = GarbageCollect();
+                size_t freed = self->GarbageCollect();
                 return ConsoleResult::Ok("Freed " + std::to_string(freed) + " bytes.");
             }
 
             if (args[0] == "reload") {
-                int changed = ReloadChanged();
+                int changed = self->ReloadChanged();
                 return ConsoleResult::Ok("Reloaded " + std::to_string(changed) + " asset(s).");
             }
 
             if (args[0] == "manifest") {
                 if (args.size() >= 2 && args[1] == "scan") {
                     std::string dir = (args.size() >= 3) ? args[2] : ".";
-                    manifest_.Scan(dir);
-                    return ConsoleResult::Ok("Scanned " + std::to_string(manifest_.Count()) + " files.");
+                    self->manifest_.Scan(dir);
+                    return ConsoleResult::Ok("Scanned " + std::to_string(self->manifest_.Count()) + " files.");
                 }
                 if (args.size() >= 2 && args[1] == "save") {
                     std::string path = (args.size() >= 3) ? args[2] : "assets.kasset";
-                    if (manifest_.Save(path)) {
+                    if (self->manifest_.Save(path)) {
                         return ConsoleResult::Ok("Manifest saved to " + path);
                     }
                     return ConsoleResult::Error("Failed to save manifest.");
                 }
                 if (args.size() >= 2 && args[1] == "load") {
                     std::string path = (args.size() >= 3) ? args[2] : "assets.kasset";
-                    if (manifest_.Load(path)) {
-                        return ConsoleResult::Ok("Loaded " + std::to_string(manifest_.Count()) + " entries.");
+                    if (self->manifest_.Load(path)) {
+                        return ConsoleResult::Ok("Loaded " + std::to_string(self->manifest_.Count()) + " entries.");
                     }
                     return ConsoleResult::Error("Failed to load manifest.");
                 }
@@ -436,6 +432,8 @@ void AssetModule::RegisterConsoleCommands() {
                 "\nUsage: assets [list|info|memory|gc|reload|manifest]");
         }, nullptr
     });
+
+    return result;
 }
 
 } // namespace koilo

--- a/engine/koilo/systems/asset/asset_module.hpp
+++ b/engine/koilo/systems/asset/asset_module.hpp
@@ -18,6 +18,7 @@
 
 #include <koilo/kernel/unified_module.hpp>
 #include <koilo/kernel/module.hpp>
+#include <koilo/kernel/console/command_provider.hpp>
 #include <koilo/kernel/asset/asset_registry.hpp>
 #include <koilo/kernel/asset/asset_converter.hpp>
 #include <koilo/kernel/asset/asset_manifest.hpp>
@@ -35,7 +36,7 @@ class KoiloKernel;
  * @class AssetModule
  * @brief Unified asset pipeline - kernel-level registry with script integration.
  */
-class AssetModule : public IModule {
+class AssetModule : public IModule, public ICommandProvider {
 public:
     AssetModule();
     ~AssetModule() override;
@@ -47,6 +48,9 @@ public:
     void Update(float dt) override;
     void Render(Color888* buffer, int width, int height) override;
     void Shutdown() override;
+
+    // ICommandProvider
+    std::vector<CommandDef> GetCommands() const override;
 
     // -- Kernel module descriptor (static lifecycle) ---------------
 
@@ -104,7 +108,6 @@ private:
     float               hotReloadTimer_ = 0.0f;
     static constexpr float kHotReloadInterval = 1.0f;
 
-    void RegisterConsoleCommands();
     void SetupFileWatcher();
 
     KL_BEGIN_FIELDS(AssetModule)

--- a/engine/koilo/systems/audio/audio_module.cpp
+++ b/engine/koilo/systems/audio/audio_module.cpp
@@ -3,7 +3,6 @@
 #include "script_audio_manager.hpp"
 #include <koilo/scripting/koiloscript_engine.hpp>
 #include <koilo/kernel/kernel.hpp>
-#include <koilo/kernel/console/console_module.hpp>
 
 namespace koilo {
 
@@ -23,26 +22,28 @@ bool AudioModule::Initialize(KoiloKernel& kernel) {
     manager_ = std::make_unique<ScriptAudioManager>();
     engine->RegisterGlobal("audio", "ScriptAudioManager", manager_.get());
 
-    // Register as kernel service if available
-    auto* console = ConsoleModule::Instance();
-    if (console) {
-        auto& cmds = console->Commands();
-        cmds.Register({"audio", "audio [status|stop]", "Audio system info and control",
-            [this](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
-                if (!manager_) return ConsoleResult::Error("Audio module not initialized");
-                if (args.empty() || args[0] == "status") {
-                    return ConsoleResult::Ok("Audio module: active");
-                }
-                if (args[0] == "stop") {
-                    manager_->StopAll();
-                    return ConsoleResult::Ok("All audio stopped.");
-                }
-                return ConsoleResult::Error("Unknown subcommand: " + args[0]);
-            }, nullptr
-        });
-    }
+    kernel.Services().RegisterTyped<ICommandProvider>("commands.audio", this);
 
     return true;
+}
+
+std::vector<CommandDef> AudioModule::GetCommands() const {
+    std::vector<CommandDef> cmds;
+    auto* mgr = manager_.get();
+    cmds.push_back({"audio", "audio [status|stop]", "Audio system info and control",
+        [mgr](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
+            if (!mgr) return ConsoleResult::Error("Audio module not initialized");
+            if (args.empty() || args[0] == "status") {
+                return ConsoleResult::Ok("Audio module: active");
+            }
+            if (args[0] == "stop") {
+                mgr->StopAll();
+                return ConsoleResult::Ok("All audio stopped.");
+            }
+            return ConsoleResult::Error("Unknown subcommand: " + args[0]);
+        }, nullptr
+    });
+    return cmds;
 }
 
 void AudioModule::Update(float dt) {

--- a/engine/koilo/systems/audio/audio_module.hpp
+++ b/engine/koilo/systems/audio/audio_module.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <koilo/kernel/unified_module.hpp>
+#include <koilo/kernel/console/command_provider.hpp>
 #include <memory>
 #include "../../registry/reflect_macros.hpp"
 
@@ -18,7 +19,7 @@ namespace koilo {
 
 class ScriptAudioManager;
 
-class AudioModule : public IModule {
+class AudioModule : public IModule, public ICommandProvider {
 public:
     AudioModule();
     ~AudioModule() override;
@@ -28,6 +29,9 @@ public:
     void Update(float dt) override;
     void Render(Color888* buffer, int width, int height) override;
     void Shutdown() override;
+
+    // ICommandProvider
+    std::vector<CommandDef> GetCommands() const override;
 
     ScriptAudioManager* GetManager() { return manager_.get(); }
 

--- a/engine/koilo/systems/ecs/component_registry.cpp
+++ b/engine/koilo/systems/ecs/component_registry.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "component_registry.hpp"
+
+namespace koilo {
+
+ComponentRegistry::ComponentRegistry()
+    : nextId_(ComponentTypeIDGenerator::GetCount()) {}
+
+ComponentTypeID ComponentRegistry::Register(std::unique_ptr<IComponentType> type) {
+    if (!type) return UINT32_MAX;
+
+    std::string name = type->GetName();
+
+    // Reject duplicate names
+    if (nameIndex_.find(name) != nameIndex_.end()) {
+        return entries_[nameIndex_[name]].id;
+    }
+
+    ComponentTypeID id = nextId_++;
+    size_t idx = entries_.size();
+    entries_.push_back({id, std::move(type)});
+    nameIndex_[name] = idx;
+    return id;
+}
+
+const IComponentType* ComponentRegistry::FindByName(const std::string& name) const {
+    auto it = nameIndex_.find(name);
+    if (it == nameIndex_.end()) return nullptr;
+    return entries_[it->second].type.get();
+}
+
+ComponentTypeID ComponentRegistry::FindIDByName(const std::string& name) const {
+    auto it = nameIndex_.find(name);
+    if (it == nameIndex_.end()) return UINT32_MAX;
+    return entries_[it->second].id;
+}
+
+const IComponentType* ComponentRegistry::GetType(ComponentTypeID id) const {
+    for (auto& e : entries_) {
+        if (e.id == id) return e.type.get();
+    }
+    return nullptr;
+}
+
+std::vector<std::string> ComponentRegistry::List() const {
+    std::vector<std::string> names;
+    names.reserve(entries_.size());
+    for (auto& e : entries_) {
+        names.push_back(e.type->GetName());
+    }
+    return names;
+}
+
+size_t ComponentRegistry::Count() const {
+    return entries_.size();
+}
+
+} // namespace koilo

--- a/engine/koilo/systems/ecs/component_registry.hpp
+++ b/engine/koilo/systems/ecs/component_registry.hpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file component_registry.hpp
+ * @brief Runtime component type registry for modular ECS.
+ *
+ * Modules register component types at runtime. IDs are assigned
+ * sequentially starting after the last compile-time ID.
+ *
+ * @date 03/30/2026
+ * @author Coela
+ */
+#pragma once
+
+#include <vector>
+#include <string>
+#include <unordered_map>
+#include <memory>
+#include "component.hpp"
+#include "component_type.hpp"
+
+namespace koilo {
+
+/**
+ * @class ComponentRegistry
+ * @brief Central registry for runtime component type metadata.
+ *
+ * Compile-time component IDs (from ComponentTypeIDGenerator) are below
+ * the base; runtime IDs start at the current compile-time count.
+ */
+class ComponentRegistry {
+public:
+    ComponentRegistry();
+
+    /**
+     * @brief Registers a runtime component type.
+     * @param type  Owned pointer to the type descriptor.
+     * @return The assigned ComponentTypeID.
+     */
+    ComponentTypeID Register(std::unique_ptr<IComponentType> type);
+
+    /**
+     * @brief Convenience: register a compile-time type T by name.
+     * @return The assigned runtime ComponentTypeID.
+     */
+    template<typename T>
+    ComponentTypeID Register(const char* name) {
+        return Register(std::make_unique<ComponentType<T>>(name));
+    }
+
+    /**
+     * @brief Finds a component type by name.
+     * @return Pointer to the descriptor, or nullptr.
+     */
+    const IComponentType* FindByName(const std::string& name) const;
+
+    /**
+     * @brief Finds the ComponentTypeID for a named component.
+     * @return The ID, or UINT32_MAX if not found.
+     */
+    ComponentTypeID FindIDByName(const std::string& name) const;
+
+    /**
+     * @brief Gets a type descriptor by its runtime ID.
+     * @return Pointer to the descriptor, or nullptr.
+     */
+    const IComponentType* GetType(ComponentTypeID id) const;
+
+    /**
+     * @brief Lists all registered runtime component type names.
+     */
+    std::vector<std::string> List() const;
+
+    /**
+     * @brief Returns the number of runtime-registered types.
+     */
+    size_t Count() const;
+
+private:
+    ComponentTypeID nextId_;
+
+    struct Entry {
+        ComponentTypeID                 id;
+        std::unique_ptr<IComponentType> type;
+    };
+
+    std::vector<Entry> entries_;
+    std::unordered_map<std::string, size_t> nameIndex_;
+};
+
+} // namespace koilo

--- a/engine/koilo/systems/ecs/component_type.hpp
+++ b/engine/koilo/systems/ecs/component_type.hpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file component_type.hpp
+ * @brief Runtime component type descriptor for modular ECS.
+ *
+ * Provides IComponentType (interface for runtime-registered components)
+ * and ComponentType<T> (convenience template that auto-implements from T).
+ *
+ * @date 03/30/2026
+ * @author Coela
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+#include <string>
+#include <new>
+#include "component.hpp"
+
+namespace koilo {
+
+/**
+ * @class IComponentType
+ * @brief Describes a component type at runtime for type-erased storage.
+ */
+class IComponentType {
+public:
+    virtual ~IComponentType() = default;
+
+    virtual const char* GetName() const = 0;
+    virtual size_t      GetSize() const = 0;
+    virtual size_t      GetAlignment() const = 0;
+
+    /// Placement-new a default instance into `dest`.
+    virtual void Construct(void* dest) const = 0;
+
+    /// Destroy the instance at `ptr` (call destructor, no dealloc).
+    virtual void Destruct(void* ptr) const = 0;
+
+    /// Copy `src` into already-constructed `dest`.
+    virtual void Copy(void* dest, const void* src) const = 0;
+
+    /// Move `src` into already-constructed `dest`.
+    virtual void Move(void* dest, void* src) const = 0;
+};
+
+/**
+ * @class ComponentType
+ * @brief Convenience template that auto-implements IComponentType for T.
+ *
+ * T must be default-constructible, copy-assignable, and move-assignable.
+ */
+template<typename T>
+class ComponentType : public IComponentType {
+public:
+    explicit ComponentType(const char* name) : name_(name) {}
+
+    const char* GetName()      const override { return name_; }
+    size_t      GetSize()      const override { return sizeof(T); }
+    size_t      GetAlignment() const override { return alignof(T); }
+
+    void Construct(void* dest) const override {
+        new (dest) T();
+    }
+
+    void Destruct(void* ptr) const override {
+        static_cast<T*>(ptr)->~T();
+    }
+
+    void Copy(void* dest, const void* src) const override {
+        *static_cast<T*>(dest) = *static_cast<const T*>(src);
+    }
+
+    void Move(void* dest, void* src) const override {
+        *static_cast<T*>(dest) = std::move(*static_cast<T*>(src));
+    }
+
+private:
+    const char* name_;
+};
+
+} // namespace koilo

--- a/engine/koilo/systems/ecs/entitymanager.hpp
+++ b/engine/koilo/systems/ecs/entitymanager.hpp
@@ -33,9 +33,9 @@ namespace koilo {
 
 /**
  * @typedef ComponentMask
- * @brief Bitset representing which components an entity has (max 64 component types).
+ * @brief Bitset representing which components an entity has (max 128 component types).
  */
-using ComponentMask = std::bitset<64>;
+using ComponentMask = std::bitset<128>;
 
 /**
  * @class IComponentArray

--- a/engine/koilo/systems/input/input_listener.hpp
+++ b/engine/koilo/systems/input/input_listener.hpp
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file input_listener.hpp
+ * @brief Event-based input with priority dispatch and consumption.
+ *
+ * Provides event structs for keyboard, mouse, and scroll input,
+ * an IInputListener interface for priority-ordered consumption,
+ * and InputListenerRegistry for managing listeners.
+ *
+ * @date 03/30/2026
+ * @author Coela
+ */
+#pragma once
+
+#include <vector>
+#include <string>
+#include <algorithm>
+#include "keycodes.hpp"
+#include <koilo/core/math/vector2d.hpp>
+
+namespace koilo {
+
+// -- Event structs -----------------------------------------------
+
+enum class KeyAction : uint8_t { Pressed, Released };
+enum class MouseButtonAction : uint8_t { Pressed, Released };
+
+struct KeyEvent {
+    KeyCode   key    = KeyCode::Unknown;
+    KeyAction action = KeyAction::Pressed;
+    bool shift = false;
+    bool ctrl  = false;
+    bool alt   = false;
+    bool consumed = false;
+};
+
+struct MouseButtonEvent {
+    MouseButton       button = MouseButton::Left;
+    MouseButtonAction action = MouseButtonAction::Pressed;
+    Vector2D          position;
+    bool consumed = false;
+};
+
+struct MouseMoveEvent {
+    Vector2D position;
+    Vector2D delta;
+    bool consumed = false;
+};
+
+struct ScrollEvent {
+    Vector2D delta;
+    bool consumed = false;
+};
+
+// -- Listener interface ------------------------------------------
+
+/**
+ * @class IInputListener
+ * @brief Interface for priority-based input event consumption.
+ *
+ * Return true from any handler to consume the event and stop
+ * propagation to lower-priority listeners.
+ */
+class IInputListener {
+public:
+    virtual ~IInputListener() = default;
+
+    virtual const char* GetName() const = 0;
+
+    /// Higher priority listeners receive events first.
+    virtual int GetPriority() const = 0;
+
+    virtual bool OnKeyEvent(KeyEvent& event) { (void)event; return false; }
+    virtual bool OnMouseButtonEvent(MouseButtonEvent& event) { (void)event; return false; }
+    virtual bool OnMouseMoveEvent(MouseMoveEvent& event) { (void)event; return false; }
+    virtual bool OnScrollEvent(ScrollEvent& event) { (void)event; return false; }
+};
+
+// -- Listener registry -------------------------------------------
+
+/**
+ * @class InputListenerRegistry
+ * @brief Manages a priority-sorted set of input listeners.
+ *
+ * Listeners are dispatched highest-priority first. If a listener
+ * returns true the event is marked consumed and propagation stops.
+ */
+class InputListenerRegistry {
+public:
+    void Register(IInputListener* listener) {
+        if (!listener) return;
+        listeners_.push_back(listener);
+        dirty_ = true;
+    }
+
+    void Unregister(IInputListener* listener) {
+        auto it = std::find(listeners_.begin(), listeners_.end(), listener);
+        if (it != listeners_.end()) {
+            listeners_.erase(it);
+        }
+    }
+
+    void DispatchKey(KeyEvent& event) {
+        EnsureSorted();
+        for (auto* l : listeners_) {
+            if (l->OnKeyEvent(event)) {
+                event.consumed = true;
+                return;
+            }
+        }
+    }
+
+    void DispatchMouseButton(MouseButtonEvent& event) {
+        EnsureSorted();
+        for (auto* l : listeners_) {
+            if (l->OnMouseButtonEvent(event)) {
+                event.consumed = true;
+                return;
+            }
+        }
+    }
+
+    void DispatchMouseMove(MouseMoveEvent& event) {
+        EnsureSorted();
+        for (auto* l : listeners_) {
+            if (l->OnMouseMoveEvent(event)) {
+                event.consumed = true;
+                return;
+            }
+        }
+    }
+
+    void DispatchScroll(ScrollEvent& event) {
+        EnsureSorted();
+        for (auto* l : listeners_) {
+            if (l->OnScrollEvent(event)) {
+                event.consumed = true;
+                return;
+            }
+        }
+    }
+
+    size_t Count() const { return listeners_.size(); }
+
+    const std::vector<IInputListener*>& GetListeners() const { return listeners_; }
+
+private:
+    void EnsureSorted() {
+        if (!dirty_) return;
+        std::stable_sort(listeners_.begin(), listeners_.end(),
+            [](const IInputListener* a, const IInputListener* b) {
+                return a->GetPriority() > b->GetPriority();
+            });
+        dirty_ = false;
+    }
+
+    std::vector<IInputListener*> listeners_;
+    bool dirty_ = false;
+};
+
+} // namespace koilo

--- a/engine/koilo/systems/input/input_module.cpp
+++ b/engine/koilo/systems/input/input_module.cpp
@@ -20,6 +20,8 @@ bool InputModule::Initialize(KoiloKernel& kernel) {
         engine->RegisterGlobal("input", "InputManager", &manager_);
     }
     kernel.Services().Register("input", &manager_);
+    kernel.Services().RegisterTyped<InputListenerRegistry>(
+        "input.listeners", &manager_.GetListenerRegistry());
     return true;
 }
 
@@ -30,6 +32,7 @@ void InputModule::Update(float dt) {
 
 void InputModule::Shutdown() {
     if (kernel_) {
+        kernel_->Services().Unregister("input.listeners");
         kernel_->Services().Unregister("input");
     }
 }

--- a/engine/koilo/systems/input/inputmanager.cpp
+++ b/engine/koilo/systems/input/inputmanager.cpp
@@ -17,6 +17,8 @@ void koilo::InputManager::Update() {
     for (auto& pair : gamepads) {
         pair.second.Update();
     }
+
+    GenerateAndDispatchEvents();
 }
 
 Gamepad& koilo::InputManager::GetGamepad(int id) {
@@ -141,6 +143,87 @@ float koilo::InputManager::GetAxis(const std::string& axis, int gamepadId) const
     if (it == axisMapping.end()) return 0.0f;
 
     return GetGamepadAxis(gamepadId, it->second);
+}
+
+void koilo::InputManager::GenerateAndDispatchEvents() {
+    if (listenerRegistry_.Count() == 0) return;
+
+    // Skip event generation on first frame (no previous state)
+    if (firstFrame_) {
+        firstFrame_ = false;
+        for (int k = 0; k < static_cast<int>(KeyCode::MaxKeyCode); ++k) {
+            prevKeys_[k] = keyboard.IsKeyHeld(static_cast<KeyCode>(k));
+        }
+        for (int b = 0; b < static_cast<int>(MouseButton::MaxButton); ++b) {
+            prevMouseButtons_[b] = mouse.IsButtonHeld(static_cast<MouseButton>(b));
+        }
+        prevMousePos_ = mouse.GetPosition();
+        return;
+    }
+
+    bool shift = keyboard.IsShiftPressed();
+    bool ctrl  = keyboard.IsCtrlPressed();
+    bool alt   = keyboard.IsAltPressed();
+
+    // Keyboard events
+    for (int k = 0; k < static_cast<int>(KeyCode::MaxKeyCode); ++k) {
+        bool cur  = keyboard.IsKeyHeld(static_cast<KeyCode>(k));
+        bool prev = prevKeys_[k];
+        if (cur && !prev) {
+            KeyEvent ev;
+            ev.key = static_cast<KeyCode>(k);
+            ev.action = KeyAction::Pressed;
+            ev.shift = shift; ev.ctrl = ctrl; ev.alt = alt;
+            listenerRegistry_.DispatchKey(ev);
+        } else if (!cur && prev) {
+            KeyEvent ev;
+            ev.key = static_cast<KeyCode>(k);
+            ev.action = KeyAction::Released;
+            ev.shift = shift; ev.ctrl = ctrl; ev.alt = alt;
+            listenerRegistry_.DispatchKey(ev);
+        }
+        prevKeys_[k] = cur;
+    }
+
+    // Mouse button events
+    Vector2D mousePos = mouse.GetPosition();
+    for (int b = 0; b < static_cast<int>(MouseButton::MaxButton); ++b) {
+        bool cur  = mouse.IsButtonHeld(static_cast<MouseButton>(b));
+        bool prev = prevMouseButtons_[b];
+        if (cur && !prev) {
+            MouseButtonEvent ev;
+            ev.button = static_cast<MouseButton>(b);
+            ev.action = MouseButtonAction::Pressed;
+            ev.position = mousePos;
+            listenerRegistry_.DispatchMouseButton(ev);
+        } else if (!cur && prev) {
+            MouseButtonEvent ev;
+            ev.button = static_cast<MouseButton>(b);
+            ev.action = MouseButtonAction::Released;
+            ev.position = mousePos;
+            listenerRegistry_.DispatchMouseButton(ev);
+        }
+        prevMouseButtons_[b] = cur;
+    }
+
+    // Mouse move event
+    Vector2D mouseDelta = mouse.GetDelta();
+    if (mouseDelta.X != 0.0f || mouseDelta.Y != 0.0f) {
+        MouseMoveEvent ev;
+        ev.position = mousePos;
+        ev.delta = mouseDelta;
+        listenerRegistry_.DispatchMouseMove(ev);
+    }
+
+    // Scroll event
+    Vector2D scroll = mouse.GetScrollDelta();
+    if (scroll.X != 0.0f || scroll.Y != 0.0f) {
+        ScrollEvent ev;
+        ev.delta = scroll;
+        listenerRegistry_.DispatchScroll(ev);
+    }
+
+    prevMousePos_ = mousePos;
 }
 
 } // namespace koilo

--- a/engine/koilo/systems/input/inputmanager.hpp
+++ b/engine/koilo/systems/input/inputmanager.hpp
@@ -14,6 +14,7 @@
 #include "keyboard.hpp"
 #include "mouse.hpp"
 #include "gamepad.hpp"
+#include "input_listener.hpp"
 #include <koilo/registry/reflect_macros.hpp>
 
 namespace koilo {
@@ -35,6 +36,17 @@ private:
 
     // Axis mapping: axis name -> gamepad axis
     std::unordered_map<std::string, GamepadAxis> axisMapping;
+
+    // Event-based input
+    InputListenerRegistry listenerRegistry_;
+
+    // Previous-frame snapshots for event generation
+    std::array<bool, static_cast<size_t>(KeyCode::MaxKeyCode)> prevKeys_{};
+    std::array<bool, static_cast<size_t>(MouseButton::MaxButton)> prevMouseButtons_{};
+    Vector2D prevMousePos_;
+    bool firstFrame_ = true;
+
+    void GenerateAndDispatchEvents();
 
     // Maximum gamepads to support
     static constexpr int MaxGamepads = 4;
@@ -203,6 +215,11 @@ public:
      * @return The axis value (-1.0 to 1.0).
      */
     float GetAxis(const std::string& axis, int gamepadId = 0) const;
+
+    /**
+     * @brief Gets the input listener registry for event-based input.
+     */
+    InputListenerRegistry& GetListenerRegistry() { return listenerRegistry_; }
 
     KL_BEGIN_FIELDS(InputManager)
         /* No reflected fields */

--- a/engine/koilo/systems/physics/physics_module.cpp
+++ b/engine/koilo/systems/physics/physics_module.cpp
@@ -3,7 +3,6 @@
 #include "physicsworld.hpp"
 #include <koilo/scripting/koiloscript_engine.hpp>
 #include <koilo/kernel/kernel.hpp>
-#include <koilo/kernel/console/console_module.hpp>
 #include <sstream>
 #include <iomanip>
 
@@ -33,44 +32,46 @@ bool PhysicsModule::Initialize(KoiloKernel& kernel) {
         engine->CallFunction("OnCollisionExit");
     });
 
-    // Register console commands if available
-    auto* console = ConsoleModule::Instance();
-    if (console) {
-        auto& cmds = console->Commands();
-        cmds.Register({"physics", "physics [status|gravity|bodies]", "Physics system info and control",
-            [this](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
-                if (!world_) return ConsoleResult::Error("Physics module not initialized");
-                if (args.empty() || args[0] == "status") {
-                    auto g = world_->GetGravity();
-                    std::ostringstream ss;
-                    ss << "Physics module: active\n"
-                       << "  Bodies: " << world_->GetBodyCount() << "\n"
-                       << std::fixed << std::setprecision(2)
-                       << "  Gravity: (" << g.X << ", " << g.Y << ", " << g.Z << ")\n"
-                       << "  Timestep: " << world_->GetFixedTimestep() << "s";
-                    return ConsoleResult::Ok(ss.str());
-                }
-                if (args[0] == "gravity" && args.size() >= 4) {
-                    try {
-                        float x = std::stof(args[1]);
-                        float y = std::stof(args[2]);
-                        float z = std::stof(args[3]);
-                        world_->SetGravity(Vector3D(x, y, z));
-                        return ConsoleResult::Ok("Gravity set to (" +
-                            args[1] + ", " + args[2] + ", " + args[3] + ")");
-                    } catch (...) {
-                        return ConsoleResult::Error("Usage: physics gravity <x> <y> <z>");
-                    }
-                }
-                if (args[0] == "bodies") {
-                    return ConsoleResult::Ok("Body count: " + std::to_string(world_->GetBodyCount()));
-                }
-                return ConsoleResult::Error("Unknown subcommand: " + args[0]);
-            }, nullptr
-        });
-    }
+    kernel.Services().RegisterTyped<ICommandProvider>("commands.physics", this);
 
     return true;
+}
+
+std::vector<CommandDef> PhysicsModule::GetCommands() const {
+    std::vector<CommandDef> cmds;
+    auto* w = world_.get();
+    cmds.push_back({"physics", "physics [status|gravity|bodies]", "Physics system info and control",
+        [w](KoiloKernel&, const std::vector<std::string>& args) -> ConsoleResult {
+            if (!w) return ConsoleResult::Error("Physics module not initialized");
+            if (args.empty() || args[0] == "status") {
+                auto g = w->GetGravity();
+                std::ostringstream ss;
+                ss << "Physics module: active\n"
+                   << "  Bodies: " << w->GetBodyCount() << "\n"
+                   << std::fixed << std::setprecision(2)
+                   << "  Gravity: (" << g.X << ", " << g.Y << ", " << g.Z << ")\n"
+                   << "  Timestep: " << w->GetFixedTimestep() << "s";
+                return ConsoleResult::Ok(ss.str());
+            }
+            if (args[0] == "gravity" && args.size() >= 4) {
+                try {
+                    float x = std::stof(args[1]);
+                    float y = std::stof(args[2]);
+                    float z = std::stof(args[3]);
+                    w->SetGravity(Vector3D(x, y, z));
+                    return ConsoleResult::Ok("Gravity set to (" +
+                        args[1] + ", " + args[2] + ", " + args[3] + ")");
+                } catch (...) {
+                    return ConsoleResult::Error("Usage: physics gravity <x> <y> <z>");
+                }
+            }
+            if (args[0] == "bodies") {
+                return ConsoleResult::Ok("Body count: " + std::to_string(w->GetBodyCount()));
+            }
+            return ConsoleResult::Error("Unknown subcommand: " + args[0]);
+        }, nullptr
+    });
+    return cmds;
 }
 
 void PhysicsModule::Update(float dt) {

--- a/engine/koilo/systems/physics/physics_module.hpp
+++ b/engine/koilo/systems/physics/physics_module.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <koilo/kernel/unified_module.hpp>
+#include <koilo/kernel/console/command_provider.hpp>
 #include <memory>
 #include "../../registry/reflect_macros.hpp"
 
@@ -17,7 +18,7 @@ namespace koilo {
 
 class PhysicsWorld;
 
-class PhysicsModule : public IModule {
+class PhysicsModule : public IModule, public ICommandProvider {
 public:
     PhysicsModule();
     ~PhysicsModule() override;
@@ -27,6 +28,9 @@ public:
     void Update(float dt) override;
     void Render(Color888* buffer, int width, int height) override;
     void Shutdown() override;
+
+    // ICommandProvider
+    std::vector<CommandDef> GetCommands() const override;
 
     PhysicsWorld* GetWorld() { return world_.get(); }
 

--- a/engine/koilo/systems/ui/render/draw_list.cpp
+++ b/engine/koilo/systems/ui/render/draw_list.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <koilo/systems/ui/render/draw_list.hpp>
+#include <koilo/systems/ui/widget_factory.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -411,6 +412,12 @@ void UIDrawList::EmitWidget(const Widget& widget, int widgetIdx, const WidgetPoo
         if (widget.onPaint) {
             CanvasDrawContext cdc(*this, r.x, r.y, r.w, r.h, font_);
             widget.onPaint(&cdc);
+        }
+        break;
+    case WidgetTag::Custom:
+        if (widget.customWidget) {
+            CanvasDrawContext cdc(*this, r.x, r.y, r.w, r.h, font_);
+            static_cast<CustomWidget*>(widget.customWidget.get())->Render(&cdc);
         }
         break;
     default:

--- a/engine/koilo/systems/ui/ui_module.cpp
+++ b/engine/koilo/systems/ui/ui_module.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "ui_module.hpp"
 #include "ui.hpp"
+#include "widget_factory.hpp"
 #include <koilo/scripting/koiloscript_engine.hpp>
 #include <koilo/kernel/kernel.hpp>
 
@@ -29,6 +30,9 @@ bool UIModule::Initialize(KoiloKernel& kernel) {
         engine->RegisterGlobal("ui", "UI", ui_.get());
     }
     kernel.Services().Register("ui", ui_.get());
+    widgetRegistry_ = std::make_unique<ui::WidgetTypeRegistry>();
+    kernel.Services().RegisterTyped<ui::WidgetTypeRegistry>(
+        "ui.widgets", widgetRegistry_.get());
     return true;
 }
 
@@ -42,8 +46,10 @@ void UIModule::Render(Color888* /*buffer*/, int /*width*/, int /*height*/) {
 
 void UIModule::Shutdown() {
     if (kernel_) {
+        kernel_->Services().Unregister("ui.widgets");
         kernel_->Services().Unregister("ui");
     }
+    widgetRegistry_.reset();
     ui_.reset();
 }
 

--- a/engine/koilo/systems/ui/ui_module.hpp
+++ b/engine/koilo/systems/ui/ui_module.hpp
@@ -18,6 +18,7 @@
 namespace koilo {
 
 class UI;
+namespace ui { class WidgetTypeRegistry; }
 
 class UIModule : public IModule {
 public:
@@ -37,6 +38,7 @@ public:
 
 private:
     std::unique_ptr<UI> ui_;
+    std::unique_ptr<ui::WidgetTypeRegistry> widgetRegistry_;
 
     /// Ensure font is loaded (lazy init).
     void EnsureFont();

--- a/engine/koilo/systems/ui/widget.hpp
+++ b/engine/koilo/systems/ui/widget.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <functional>
 #include <vector>
+#include <memory>
 #include <koilo/registry/reflect_macros.hpp>
 #include <koilo/systems/ui/icon_ids.hpp>
 #include "drag_drop.hpp"
@@ -151,6 +152,7 @@ enum class WidgetTag : uint8_t {
     FloatingPanel, ///< Detachable floating window.
     VirtualList,   ///< Virtualized scrolling list.
     Canvas2D,      ///< Custom 2D drawing surface.
+    Custom,        ///< Module-defined custom widget (rendered via CustomWidget).
     Count          ///< Total number of widget types.
 };
 
@@ -763,6 +765,12 @@ struct Widget {
     // -- Canvas2D -------------------------------------------------
     /// Paint callback (CanvasDrawContext* passed as void* to avoid circular include).
     std::function<void(void* /*CanvasDrawContext*/ )> onPaint;
+
+    // -- Custom widget (WidgetTag::Custom) ------------------------
+    /// Type name used to create this custom widget via WidgetTypeRegistry.
+    StringId customTypeName = NullStringId;
+    /// Owned custom widget instance (rendering + state).
+    std::shared_ptr<void> customWidget; // actually CustomWidget*, stored type-erased
 
     // -- Event callbacks (script function names) ------------------
     StringId onClickId    = NullStringId; ///< Script callback for click events.

--- a/engine/koilo/systems/ui/widget_factory.hpp
+++ b/engine/koilo/systems/ui/widget_factory.hpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/**
+ * @file widget_factory.hpp
+ * @brief Extensible widget factory for custom UI widgets.
+ *
+ * Modules register IWidgetFactory instances to provide custom widget types.
+ * Custom widgets render via a CanvasDrawContext facade, using the same
+ * drawing primitives as built-in widgets.
+ *
+ * @date 03/30/2026
+ * @author Coela
+ */
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace koilo {
+namespace ui {
+
+/**
+ * @class CustomWidget
+ * @brief Base class for custom widget rendering and state.
+ *
+ * Subclass this and override Render() to draw via the CanvasDrawContext.
+ * The context pointer is passed as void* to avoid circular includes
+ * (cast to CanvasDrawContext* inside Render).
+ */
+class CustomWidget {
+public:
+    virtual ~CustomWidget() = default;
+
+    /// Called each frame the widget is visible.
+    /// @param ctx  Pointer to CanvasDrawContext (cast internally).
+    virtual void Render(void* ctx) = 0;
+
+    /// Called when the widget receives a click.
+    virtual void OnClick() {}
+
+    /// Called when the widget value changes (if applicable).
+    virtual void OnChange() {}
+
+    /// Human-readable type name (must match the factory).
+    virtual const char* GetTypeName() const = 0;
+};
+
+/**
+ * @class IWidgetFactory
+ * @brief Interface for creating custom widget instances by type name.
+ */
+class IWidgetFactory {
+public:
+    virtual ~IWidgetFactory() = default;
+
+    /// The custom widget type name this factory produces (e.g. "ColorWheel").
+    virtual const char* GetTypeName() const = 0;
+
+    /// Create a new instance of the custom widget.
+    virtual std::unique_ptr<CustomWidget> Create() = 0;
+};
+
+/**
+ * @class WidgetTypeRegistry
+ * @brief Central registry for custom widget factories.
+ *
+ * Registered as the "ui.widgets" kernel service.
+ */
+class WidgetTypeRegistry {
+public:
+    /// Register a factory. Ownership is taken.
+    void Register(std::unique_ptr<IWidgetFactory> factory) {
+        if (!factory) return;
+        std::string name = factory->GetTypeName();
+        factories_[name] = std::move(factory);
+    }
+
+    /// Create a custom widget by type name.
+    /// @return New instance, or nullptr if the type is not registered.
+    std::unique_ptr<CustomWidget> CreateByName(const std::string& name) const {
+        auto it = factories_.find(name);
+        if (it == factories_.end()) return nullptr;
+        return it->second->Create();
+    }
+
+    /// Check if a custom widget type is registered.
+    bool Has(const std::string& name) const {
+        return factories_.find(name) != factories_.end();
+    }
+
+    /// List all registered custom widget type names.
+    std::vector<std::string> ListTypes() const {
+        std::vector<std::string> names;
+        names.reserve(factories_.size());
+        for (auto& [name, _] : factories_) {
+            names.push_back(name);
+        }
+        return names;
+    }
+
+    /// Number of registered factories.
+    size_t Count() const { return factories_.size(); }
+
+private:
+    std::unordered_map<std::string, std::unique_ptr<IWidgetFactory>> factories_;
+};
+
+} // namespace ui
+} // namespace koilo

--- a/tests/engine/ecs/testcomponent.cpp
+++ b/tests/engine/ecs/testcomponent.cpp
@@ -9,6 +9,7 @@
 
 #include "testcomponent.hpp"
 #include <koilo/systems/ecs/component.hpp>
+#include <koilo/systems/ecs/component_registry.hpp>
 
 using namespace koilo;
 
@@ -72,4 +73,53 @@ void TestComponent::RunAllTests() {
     RUN_TEST(TestComponentTypeIDConsistency);
     RUN_TEST(TestComponentTypeIDCount);
     RUN_TEST(TestMultipleComponentTypes);
+    RUN_TEST(TestRegistryRegisterAndFind);
+    RUN_TEST(TestRegistryIDsAfterCompileTime);
+    RUN_TEST(TestRegistryDuplicateName);
+    RUN_TEST(TestRegistryList);
+}
+
+// ========== Component Registry Tests (#29) ==========
+
+struct RuntimeComp1 { float health; };
+struct RuntimeComp2 { int ammo; };
+
+void TestComponent::TestRegistryRegisterAndFind() {
+    ComponentRegistry reg;
+    ComponentTypeID id = reg.Register<RuntimeComp1>("Health");
+    TEST_ASSERT_TRUE(id != UINT32_MAX);
+
+    const IComponentType* type = reg.FindByName("Health");
+    TEST_ASSERT_NOT_NULL(type);
+    TEST_ASSERT_EQUAL_STRING("Health", type->GetName());
+    TEST_ASSERT_EQUAL(sizeof(RuntimeComp1), type->GetSize());
+}
+
+void TestComponent::TestRegistryIDsAfterCompileTime() {
+    ComponentRegistry reg;
+    ComponentTypeID compileCount = ComponentTypeIDGenerator::GetCount();
+    ComponentTypeID id1 = reg.Register<RuntimeComp1>("RT1");
+    ComponentTypeID id2 = reg.Register<RuntimeComp2>("RT2");
+
+    TEST_ASSERT_TRUE(id1 >= compileCount);
+    TEST_ASSERT_TRUE(id2 > id1);
+}
+
+void TestComponent::TestRegistryDuplicateName() {
+    ComponentRegistry reg;
+    ComponentTypeID id1 = reg.Register<RuntimeComp1>("Dup");
+    ComponentTypeID id2 = reg.Register<RuntimeComp2>("Dup");
+
+    // Same name returns the existing ID
+    TEST_ASSERT_EQUAL(id1, id2);
+    TEST_ASSERT_EQUAL(1, reg.Count());
+}
+
+void TestComponent::TestRegistryList() {
+    ComponentRegistry reg;
+    reg.Register<RuntimeComp1>("Alpha");
+    reg.Register<RuntimeComp2>("Beta");
+
+    auto names = reg.List();
+    TEST_ASSERT_EQUAL(2, names.size());
 }

--- a/tests/engine/ecs/testcomponent.hpp
+++ b/tests/engine/ecs/testcomponent.hpp
@@ -19,6 +19,13 @@ public:
     static void TestComponentTypeIDConsistency();
     static void TestComponentTypeIDCount();
     static void TestMultipleComponentTypes();
+
+    // Component registry tests (#29)
+    static void TestRegistryRegisterAndFind();
+    static void TestRegistryIDsAfterCompileTime();
+    static void TestRegistryDuplicateName();
+    static void TestRegistryList();
+
     static void RunAllTests();
 };
 

--- a/tests/engine/kernel/testkernel.cpp
+++ b/tests/engine/kernel/testkernel.cpp
@@ -6,6 +6,7 @@
 #include <koilo/kernel/message_types.hpp>
 #include <koilo/kernel/capabilities.hpp>
 #include <koilo/kernel/service_registry.hpp>
+#include <koilo/kernel/console/command_provider.hpp>
 #include <koilo/kernel/module_manager.hpp>
 #include <koilo/kernel/kernel.hpp>
 #include <cstring>
@@ -305,6 +306,51 @@ void TestKernel::TestServiceList() {
     TEST_ASSERT_EQUAL(2, list.size());
 }
 
+void TestKernel::TestServiceTypedRegisterAndGet() {
+    ServiceRegistry reg;
+
+    struct MockProvider : ICommandProvider {
+        std::vector<CommandDef> GetCommands() const override { return {}; }
+    };
+    MockProvider provider;
+
+    reg.RegisterTyped<ICommandProvider>("commands.test", &provider);
+    TEST_ASSERT_TRUE(reg.Has("commands.test"));
+
+    auto* result = reg.Get<ICommandProvider>("commands.test");
+    TEST_ASSERT_NOT_NULL(result);
+    TEST_ASSERT_EQUAL_PTR(&provider, result);
+}
+
+void TestKernel::TestServiceListByPrefix() {
+    ServiceRegistry reg;
+    int a = 1, b = 2, c = 3;
+    reg.Register("commands.audio", &a);
+    reg.Register("commands.physics", &b);
+    reg.Register("render.backend", &c);
+
+    auto cmdList = reg.ListByPrefix("commands.");
+    TEST_ASSERT_EQUAL(2, cmdList.size());
+
+    auto renderList = reg.ListByPrefix("render.");
+    TEST_ASSERT_EQUAL(1, renderList.size());
+
+    auto emptyList = reg.ListByPrefix("nonexistent.");
+    TEST_ASSERT_EQUAL(0, emptyList.size());
+}
+
+void TestKernel::TestServiceUnregisterCleansType() {
+    ServiceRegistry reg;
+    int val = 42;
+    reg.RegisterTyped<int>("typed.svc", &val);
+    TEST_ASSERT_TRUE(reg.Has("typed.svc"));
+    TEST_ASSERT_EQUAL(42, *reg.Get<int>("typed.svc"));
+
+    reg.Unregister("typed.svc");
+    TEST_ASSERT_FALSE(reg.Has("typed.svc"));
+    TEST_ASSERT_NULL(reg.Get<int>("typed.svc"));
+}
+
 // --- Module Manager ---
 
 static bool g_moduleAInit = false;
@@ -518,6 +564,9 @@ void TestKernel::RunAllTests() {
     RUN_TEST(TestKernel::TestServiceOverwrite);
     RUN_TEST(TestKernel::TestServiceUnregister);
     RUN_TEST(TestKernel::TestServiceList);
+    RUN_TEST(TestKernel::TestServiceTypedRegisterAndGet);
+    RUN_TEST(TestKernel::TestServiceListByPrefix);
+    RUN_TEST(TestKernel::TestServiceUnregisterCleansType);
 
     // Module manager
     RUN_TEST(TestKernel::TestModuleRegistration);

--- a/tests/engine/kernel/testkernel.hpp
+++ b/tests/engine/kernel/testkernel.hpp
@@ -39,6 +39,9 @@ public:
     static void TestServiceOverwrite();
     static void TestServiceUnregister();
     static void TestServiceList();
+    static void TestServiceTypedRegisterAndGet();
+    static void TestServiceListByPrefix();
+    static void TestServiceUnregisterCleansType();
 
     // Module manager
     static void TestModuleRegistration();

--- a/tests/engine/systems/input/testinputmanager.cpp
+++ b/tests/engine/systems/input/testinputmanager.cpp
@@ -96,6 +96,87 @@ void TestInputManager::TestEdgeCases() {
     float axis = manager.GetAxis("nonexistent");
     TEST_ASSERT_FLOAT_WITHIN(0.01f, 0.0f, axis);
 }
+
+// ========== Input Listener Tests (#28) ==========
+
+namespace {
+
+struct TestListener : koilo::IInputListener {
+    const char* name;
+    int priority;
+    int keyCalls = 0;
+    bool consumeKeys = false;
+
+    TestListener(const char* n, int p) : name(n), priority(p) {}
+    const char* GetName() const override { return name; }
+    int GetPriority() const override { return priority; }
+
+    bool OnKeyEvent(koilo::KeyEvent& event) override {
+        ++keyCalls;
+        return consumeKeys;
+    }
+};
+
+} // namespace
+
+void TestInputManager::TestListenerRegistryDispatch() {
+    koilo::InputListenerRegistry reg;
+    TestListener listener("test", 0);
+    reg.Register(&listener);
+
+    koilo::KeyEvent ev;
+    ev.key = koilo::KeyCode::Space;
+    ev.action = koilo::KeyAction::Pressed;
+    reg.DispatchKey(ev);
+
+    TEST_ASSERT_EQUAL(1, listener.keyCalls);
+    TEST_ASSERT_FALSE(ev.consumed);
+}
+
+void TestInputManager::TestListenerPriorityOrder() {
+    koilo::InputListenerRegistry reg;
+    TestListener low("low", 10);
+    TestListener high("high", 100);
+
+    reg.Register(&low);
+    reg.Register(&high);
+
+    // High priority should be first in sorted order
+    auto& listeners = reg.GetListeners();
+    TEST_ASSERT_EQUAL(2, listeners.size());
+
+    // Dispatch to trigger sort
+    koilo::KeyEvent ev;
+    ev.key = koilo::KeyCode::A;
+    ev.action = koilo::KeyAction::Pressed;
+    reg.DispatchKey(ev);
+
+    TEST_ASSERT_EQUAL(1, high.keyCalls);
+    TEST_ASSERT_EQUAL(1, low.keyCalls);
+
+    // Verify sorted: first listener should be high priority
+    TEST_ASSERT_EQUAL(100, listeners[0]->GetPriority());
+    TEST_ASSERT_EQUAL(10, listeners[1]->GetPriority());
+}
+
+void TestInputManager::TestListenerConsumption() {
+    koilo::InputListenerRegistry reg;
+    TestListener high("high", 100);
+    TestListener low("low", 10);
+    high.consumeKeys = true;
+
+    reg.Register(&low);
+    reg.Register(&high);
+
+    koilo::KeyEvent ev;
+    ev.key = koilo::KeyCode::Escape;
+    ev.action = koilo::KeyAction::Pressed;
+    reg.DispatchKey(ev);
+
+    TEST_ASSERT_TRUE(ev.consumed);
+    TEST_ASSERT_EQUAL(1, high.keyCalls);
+    TEST_ASSERT_EQUAL(0, low.keyCalls); // Consumed, never reached
+}
 // ========== Test Runner ==========
 
 void TestInputManager::RunAllTests() {
@@ -112,4 +193,7 @@ void TestInputManager::RunAllTests() {
     RUN_TEST(TestIsActionHeld);
     RUN_TEST(TestGetAxis);
     RUN_TEST(TestEdgeCases);
+    RUN_TEST(TestListenerRegistryDispatch);
+    RUN_TEST(TestListenerPriorityOrder);
+    RUN_TEST(TestListenerConsumption);
 }

--- a/tests/engine/systems/input/testinputmanager.hpp
+++ b/tests/engine/systems/input/testinputmanager.hpp
@@ -39,6 +39,11 @@ public:
     // Edge case & integration tests
     static void TestEdgeCases();
 
+    // Input listener tests (#28)
+    static void TestListenerRegistryDispatch();
+    static void TestListenerPriorityOrder();
+    static void TestListenerConsumption();
+
     /**
      * @brief Runs all test methods.
      */

--- a/tests/engine/systems/ui/testwidget.cpp
+++ b/tests/engine/systems/ui/testwidget.cpp
@@ -15,6 +15,7 @@
 #include <koilo/systems/ui/content_browser.hpp>
 #include <koilo/systems/ui/node_graph.hpp>
 #include <koilo/systems/ui/preferences_panel.hpp>
+#include <koilo/systems/ui/widget_factory.hpp>
 #include <cstring>
 
 using namespace koilo::ui;
@@ -1743,6 +1744,53 @@ void TestWidget::TestPreferencesBuild() {
     TEST_ASSERT_TRUE(!prefs.IsVisible());
 }
 
+// ========== Widget Factory (#30) ==========
+
+namespace {
+
+struct TestCustomWidget : CustomWidget {
+    int renderCalls = 0;
+    void Render(void* /*ctx*/) override { ++renderCalls; }
+    const char* GetTypeName() const override { return "TestGauge"; }
+};
+
+struct TestGaugeFactory : IWidgetFactory {
+    const char* GetTypeName() const override { return "TestGauge"; }
+    std::unique_ptr<CustomWidget> Create() override {
+        return std::make_unique<TestCustomWidget>();
+    }
+};
+
+} // namespace
+
+void TestWidget::TestWidgetFactoryRegisterAndCreate() {
+    WidgetTypeRegistry reg;
+    reg.Register(std::make_unique<TestGaugeFactory>());
+
+    TEST_ASSERT_TRUE(reg.Has("TestGauge"));
+    TEST_ASSERT_EQUAL(1, (int)reg.Count());
+
+    auto widget = reg.CreateByName("TestGauge");
+    TEST_ASSERT_NOT_NULL(widget.get());
+    TEST_ASSERT_EQUAL_STRING("TestGauge", widget->GetTypeName());
+}
+
+void TestWidget::TestWidgetFactoryListTypes() {
+    WidgetTypeRegistry reg;
+    reg.Register(std::make_unique<TestGaugeFactory>());
+
+    auto types = reg.ListTypes();
+    TEST_ASSERT_EQUAL(1, (int)types.size());
+    TEST_ASSERT_EQUAL_STRING("TestGauge", types[0].c_str());
+}
+
+void TestWidget::TestWidgetFactoryUnknownType() {
+    WidgetTypeRegistry reg;
+    auto widget = reg.CreateByName("NonExistent");
+    TEST_ASSERT_NULL(widget.get());
+    TEST_ASSERT_FALSE(reg.Has("NonExistent"));
+}
+
 // ========== Test Runner ==========
 
 void TestWidget::RunAllTests() {
@@ -1872,4 +1920,9 @@ void TestWidget::RunAllTests() {
 
     // Preferences panel
     RUN_TEST(TestWidget::TestPreferencesBuild);
+
+    // Widget factory (#30)
+    RUN_TEST(TestWidget::TestWidgetFactoryRegisterAndCreate);
+    RUN_TEST(TestWidget::TestWidgetFactoryListTypes);
+    RUN_TEST(TestWidget::TestWidgetFactoryUnknownType);
 }

--- a/tests/engine/systems/ui/testwidget.hpp
+++ b/tests/engine/systems/ui/testwidget.hpp
@@ -143,5 +143,10 @@ public:
     // Preferences panel tests
     static void TestPreferencesBuild();
 
+    // Widget factory (#30)
+    static void TestWidgetFactoryRegisterAndCreate();
+    static void TestWidgetFactoryListTypes();
+    static void TestWidgetFactoryUnknownType();
+
     static void RunAllTests();
 };


### PR DESCRIPTION
…stom UI widgets.

### Added
- Typed service registry: `RegisterTyped<T>()`, `Get<T>()` with debug type-safety assertions, `ListByPrefix()` for service discovery (#27)
- `ICommandProvider` interface - modules declare console commands without coupling to ConsoleModule; discovered via `"commands.*"` prefix scan (#26)
- Input event system: `KeyEvent`, `MouseButtonEvent`, `MouseMoveEvent`, `ScrollEvent` structs with `IInputListener` priority-based dispatch and consumption (#28)
- `InputListenerRegistry` registered as `"input.listeners"` kernel service
- ECS component registry: `IComponentType` / `ComponentType<T>` descriptors, `ComponentRegistry` with runtime ID assignment after compile-time IDs (#29)
- Widget factory: `IWidgetFactory` / `CustomWidget` / `WidgetTypeRegistry` for module-defined UI widgets rendered via `CanvasDrawContext` (#30)
- `WidgetTag::Custom` enum value with `customWidget` field on Widget struct

### Changed
- `ComponentMask` expanded from `bitset<64>` to `bitset<128>`
- Audio, AI, Physics, and Asset modules migrated from direct `ConsoleModule::Instance()` to `ICommandProvider` pattern
- `InputManager::Update()` now generates events by diffing current vs previous frame state (polling API unchanged)